### PR TITLE
Condarized version updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 install:
   - export PACKAGE_NAME=cpsr
   # Setting up channels and install dependencies
-  - conda config --add channels defaults --add channels pcgr --add channels bioconda --add channels conda-forge
+  - conda config --add channels pcgr --add channels bioconda --add channels conda-forge
   - conda install -q python=$TRAVIS_PYTHON_VERSION pip requests conda-build jinja2 anaconda-client
   # Building package
   - conda build conda_pkg/${PACKAGE_NAME}

--- a/conda_pkg/cpsr/build.sh
+++ b/conda_pkg/cpsr/build.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+R -e "library(devtools); devtools::install_github('hms-dbmi/UpSetR',   dependencies=FALSE, args=c('--library=${PREFIX}/lib/R/library'))"
+R -e "library(devtools); devtools::install_github('kassambara/ggpubr', dependencies=FALSE, args=c('--library=${PREFIX}/lib/R/library'))"
+
 mkdir -p ${PREFIX}/bin
 chmod +x ${SRC_DIR}/*.py
 mv ${SRC_DIR}/*.py ${PREFIX}/bin/

--- a/conda_pkg/cpsr/meta.yaml
+++ b/conda_pkg/cpsr/meta.yaml
@@ -13,7 +13,7 @@ build:
 
 requirements:
   run:
-    - pcgr
+    - pcgr >=v0.8.0.1
 
 test:
   commands:

--- a/cpsr.py
+++ b/cpsr.py
@@ -436,7 +436,7 @@ def run_cpsr(host_directories, docker_image_version, config_options, sample_id, 
       if config_options['other']['vep_skip_intergenic'] == 1:
          vep_options = vep_options + " --no_intergenic"
       if not docker_image_version:
-         conda_prefix = os.environ.get('CONDA_PREFIX') or os.path.dirname(os.path.dirname(sys.executable))
+         conda_prefix = os.path.dirname(os.path.dirname(sys.executable))
          loftee_dir = os.path.join(conda_prefix, 'share', 'loftee')
          assert os.path.isdir(loftee_dir), 'LoF VEP plugin is not found in ' + loftee_dir + '. Please make sure you installed pcgr conda package and have corresponding conda environment active.'
          vep_options += " --plugin LoF,loftee_path:" + loftee_dir + " --dir_plugins " + loftee_dir

--- a/cpsr.py
+++ b/cpsr.py
@@ -436,7 +436,8 @@ def run_cpsr(host_directories, docker_image_version, config_options, sample_id, 
       if config_options['other']['vep_skip_intergenic'] == 1:
          vep_options = vep_options + " --no_intergenic"
       if not docker_image_version:
-         loftee_dir = os.path.join(os.environ['CONDA_PREFIX'], 'share', 'loftee')
+         conda_prefix = os.environ.get('CONDA_PREFIX') or os.path.dirname(os.path.dirname(sys.executable))
+         loftee_dir = os.path.join(conda_prefix, 'share', 'loftee')
          assert os.path.isdir(loftee_dir), 'LoF VEP plugin is not found in ' + loftee_dir + '. Please make sure you installed pcgr conda package and have corresponding conda environment active.'
          vep_options += " --plugin LoF,loftee_path:" + loftee_dir + " --dir_plugins " + loftee_dir
       else:


### PR DESCRIPTION
Following my question about the Dockerfile changes https://github.com/sigven/cpsr/issues/11#issuecomment-494652168
I played a bit and figured that adding just 2 libraries (UpSetR and ggpubr) into the condarized install seems to do the job. Both docker-free CPSR and PCGR are working well for me. Doesn't guarantee I wouldn't hit some missing dependency in the future though, but I'll leave it for now since it's working.