### PR TITLE
Conda: add dependencies and pin PCGR

### DIFF
--- a/conda_pkg/cpsr/build.sh
+++ b/conda_pkg/cpsr/build.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-R -e "library(devtools); devtools::install_github('hms-dbmi/UpSetR',   dependencies=FALSE, args=c('--library=${PREFIX}/lib/R/library'))"
-R -e "library(devtools); devtools::install_github('kassambara/ggpubr', dependencies=FALSE, args=c('--library=${PREFIX}/lib/R/library'))"
-
 mkdir -p ${PREFIX}/bin
 chmod +x ${SRC_DIR}/*.py
 mv ${SRC_DIR}/*.py ${PREFIX}/bin/

--- a/conda_pkg/cpsr/meta.yaml
+++ b/conda_pkg/cpsr/meta.yaml
@@ -14,6 +14,8 @@ build:
 requirements:
   run:
     - pcgr >=v0.8.1.1
+    - r-upsetr
+    - r-ggpubr
 
 test:
   commands:

--- a/conda_pkg/cpsr/meta.yaml
+++ b/conda_pkg/cpsr/meta.yaml
@@ -13,7 +13,7 @@ build:
 
 requirements:
   run:
-    - pcgr >=v0.8.0.1
+    - pcgr >=v0.8.1.1
 
 test:
   commands:


### PR DESCRIPTION
Conda-related PR: move new R dependencies into conda meta.yaml. And Pin to the latest PCGR to trigger package rebuild.