### PR TITLE
GitHub Actions: create tag

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -14,3 +14,7 @@ replace = version: {new_version}
 [bumpversion:file:conda/env/yml/pkgdown.yml]
 search = cpsr =={current_version}
 replace = cpsr =={new_version}
+
+[bumpversion:file:.github/workflows/build_conda.yaml]
+search = VERSION: '{current_version}'
+replace = VERSION: '{new_version}'

--- a/.github/workflows/build_conda.yaml
+++ b/.github/workflows/build_conda.yaml
@@ -9,6 +9,7 @@ env:
   atoken: ${{ secrets.ANACONDA_UPLOAD_TOKEN }}
   recipe_path: conda/recipe
   env_yml_path: conda/env/yml
+  VERSION: '0.7.7' # versioned by bump2version
 jobs:
   build_conda_pkgs:
     # When merging to one of the branches above and the commit message matches
@@ -65,3 +66,14 @@ jobs:
             Rscript -e "packageVersion('cpsr')"
             Rscript -e "pkgdown::deploy_to_branch(pkg = '.', commit_message = paste(pkgdown:::construct_commit_message('.'), '- see https://sigven.github.io/cpsr/'), branch = 'gh-pages', new_process = FALSE)"
 
+      - name: Create tag
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const the_tag_name = 'refs/tags/v' + process.env.VERSION
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: the_tag_name,
+              sha: context.sha
+            })


### PR DESCRIPTION
This is for creating and pushing a git tag after a successful pkgdown deployment.