### PR TITLE
Use `styler` for consistent Rmd/R file styling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+# All available hooks: https://pre-commit.com/hooks.html
+# R specific hooks: https://github.com/lorenzwalthert/precommit
+repos:
+-   repo: https://github.com/lorenzwalthert/precommit
+    rev: v0.3.2
+    hooks:
+    -   id: style-files
+        args: [--style_pkg=styler, --style_fun=tidyverse_style]
+        exclude:  > 
+          (?x)^(
+          tests/testthat/.*\.R|
+          renv/.*
+          )$
+    -   id: use-tidy-description
+    -   id: readme-rmd-rendered
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.2.0
+    hooks:
+    -   id: check-added-large-files
+        args: ['--maxkb=200']
+-   repo: local
+    hooks:
+    -   id: forbid-to-commit
+        name: Don't commit common R artifacts
+        entry: Cannot commit .Rhistory, .RData, .Rds or .rds.
+        language: fail
+        files: '\.Rhistory|\.RData|\.Rds|\.rds$'
+        # `exclude: <regex>` to allow committing specific files.

--- a/R/cpsr_functions.R
+++ b/R/cpsr_functions.R
@@ -8,17 +8,16 @@
 
 generate_cpsr_report <- function(project_directory = NULL,
                                  pcgr_data = NULL,
-                                 cpsr_config = NULL){
-
-
+                                 cpsr_config = NULL) {
   invisible(assertthat::assert_that(
     !is.null(cpsr_config),
-    msg = "Object 'cpsr_config' cannot be NULL"))
+    msg = "Object 'cpsr_config' cannot be NULL"
+  ))
 
-  query_vcf2tsv <- cpsr_config[['required_args']][['query_vcf2tsv']]
-  virtual_panel_id <- cpsr_config[['required_args']][['virtual_panel_id']]
-  sample_name <- cpsr_config[['required_args']][['sample_name']]
-  custom_bed <- cpsr_config[['custom_panel']][['bed_fname']]
+  query_vcf2tsv <- cpsr_config[["required_args"]][["query_vcf2tsv"]]
+  virtual_panel_id <- cpsr_config[["required_args"]][["virtual_panel_id"]]
+  sample_name <- cpsr_config[["required_args"]][["sample_name"]]
+  custom_bed <- cpsr_config[["custom_panel"]][["bed_fname"]]
 
   cps_report <-
     pcgrr::init_report(
@@ -27,13 +26,15 @@ generate_cpsr_report <- function(project_directory = NULL,
       pcgr_data = pcgr_data,
       type = "germline",
       virtual_panel_id = virtual_panel_id,
-      custom_bed = custom_bed)
+      custom_bed = custom_bed
+    )
   if (is.null(cps_report$metadata$gene_panel)) {
     return(NULL)
   }
 
   cpsr_tier_display_cols <-
-    c("SYMBOL",
+    c(
+      "SYMBOL",
       "CLINVAR_PHENOTYPE",
       "CONSEQUENCE",
       "PROTEIN_CHANGE",
@@ -70,11 +71,13 @@ generate_cpsr_report <- function(project_directory = NULL,
       "TUMOR_SUPPRESSOR",
       "GLOBAL_AF_GNOMAD",
       cps_report[["metadata"]][["config"]][["popgen"]][["vcftag_gnomad"]],
-      "GENOMIC_CHANGE", "GENOME_VERSION")
+      "GENOMIC_CHANGE", "GENOME_VERSION"
+    )
 
   ## define tags/variables to display in data tables (secondary findings)
   cpsr_sf_display_cols <-
-    c("SYMBOL",
+    c(
+      "SYMBOL",
       "CONSEQUENCE",
       "CLINVAR_CLASSIFICATION",
       "CLINVAR_PHENOTYPE",
@@ -102,11 +105,13 @@ generate_cpsr_report <- function(project_directory = NULL,
       "TUMOR_SUPPRESSOR",
       "GLOBAL_AF_GNOMAD",
       cps_report[["metadata"]][["config"]][["popgen"]][["vcftag_gnomad"]],
-      "GENOMIC_CHANGE", "GENOME_VERSION")
+      "GENOMIC_CHANGE", "GENOME_VERSION"
+    )
 
   ## define tags/variables to display in data tables (GWAS findings)
   cpsr_gwas_display_cols <-
-    c("SYMBOL",
+    c(
+      "SYMBOL",
       "CONSEQUENCE",
       "GWAS_CITATION",
       "PROTEIN_CHANGE",
@@ -132,11 +137,13 @@ generate_cpsr_report <- function(project_directory = NULL,
       "DBSNP",
       "GLOBAL_AF_GNOMAD",
       "GENOMIC_CHANGE",
-      "GENOME_VERSION")
+      "GENOME_VERSION"
+    )
 
   ## define tags/variables to display in output TSV
   cpsr_tsv_cols <-
-    c("GENOMIC_CHANGE",
+    c(
+      "GENOMIC_CHANGE",
       "VAR_ID",
       "GENOTYPE",
       "GENOME_VERSION",
@@ -195,19 +202,21 @@ generate_cpsr_report <- function(project_directory = NULL,
       "N_INSILICO_SPLICING_NEUTRAL",
       "N_INSILICO_SPLICING_AFFECTED",
       "GLOBAL_AF_GNOMAD",
-      cps_report[["metadata"]][["config"]][["popgen"]][["vcftag_gnomad"]])
+      cps_report[["metadata"]][["config"]][["popgen"]][["vcftag_gnomad"]]
+    )
 
   if (query_vcf2tsv != "None.gz") {
     if (!file.exists(query_vcf2tsv) | file.size(query_vcf2tsv) == 0) {
-        pcgrr::log4r_warn(
-        paste0("File ",
-               query_vcf2tsv,
-               " does not exist or has zero size"))
-
-    }else{
+      pcgrr::log4r_warn(
+        paste0(
+          "File ",
+          query_vcf2tsv,
+          " does not exist or has zero size"
+        )
+      )
+    } else {
       if (!is.null(cpsr_config) & query_vcf2tsv != "None.gz") {
-
-          pcgrr::log4r_info("Retrieving ALL variants: GWAS tag SNPs / variants in ACMG secondary findings list / target predisposition genes")
+        pcgrr::log4r_info("Retrieving ALL variants: GWAS tag SNPs / variants in ACMG secondary findings list / target predisposition genes")
         ## read calls
         calls <-
           pcgrr::get_calls(
@@ -217,17 +226,21 @@ generate_cpsr_report <- function(project_directory = NULL,
             cpsr_config,
             oncotree =
               cps_report[["metadata"]][["phenotype_ontology"]][["oncotree_query"]],
-            cpsr = TRUE)
+            cpsr = TRUE
+          )
         if (nrow(calls) == 0) {
-            pcgrr::log4r_warn(paste0("There are zero calls in input file ",
-                            "- no report will be produced"))
+          pcgrr::log4r_warn(paste0(
+            "There are zero calls in input file ",
+            "- no report will be produced"
+          ))
           return(NULL)
         }
 
         ## remove any existing VCF INFO column that coincide with variables
         ## established by CPSR
         cpsr_generated_cols <-
-          c("CPSR_CLASSIFICATION_SOURCE",
+          c(
+            "CPSR_CLASSIFICATION_SOURCE",
             "CPSR_CLASSIFICATION",
             "CPSR_PATHOGENICITY_SCORE",
             "CPSR_CLASSIFICATION_DOC",
@@ -238,15 +251,20 @@ generate_cpsr_report <- function(project_directory = NULL,
             "N_INSILICO_TOLERATED",
             "N_INSILICO_SPLICING_NEUTRAL",
             "N_INSILICO_SPLICING_AFFECTED",
-            pcgrr::cpsr_acmg$evidence_codes$cpsr_evidence_code)
+            pcgrr::cpsr_acmg$evidence_codes$cpsr_evidence_code
+          )
 
         calls <- calls[, !(colnames(calls) %in% cpsr_generated_cols)]
 
         pcgrr::log4r_info("------")
         pcgrr::log4r_info(
-          paste0("Considering variants in the targeted predisposition genes: ",
-                 paste(unique(sort(cps_report$metadata$gene_panel$genes$symbol)),
-                       collapse=", ")))
+          paste0(
+            "Considering variants in the targeted predisposition genes: ",
+            paste(unique(sort(cps_report$metadata$gene_panel$genes$symbol)),
+              collapse = ", "
+            )
+          )
+        )
 
         if (cpsr_config[["ignore_noncoding"]] == T) {
           n_noncoding_vars <- calls %>%
@@ -257,18 +275,17 @@ generate_cpsr_report <- function(project_directory = NULL,
               "Excluding n = ",
               n_noncoding_vars,
               " variants for classification (option --ignore_noncoding)"
-              )
+            )
           )
           calls <- calls %>%
             dplyr::filter(.data$CODING_STATUS == "coding")
           if (NROW(calls) == 0) {
-              pcgrr::log4r_warn(paste0(
+            pcgrr::log4r_warn(paste0(
               "There are zero remaining protein-coding ",
-              "calls in input file - no report will be produced")
-              )
+              "calls in input file - no report will be produced"
+            ))
             return(NULL)
           }
-
         }
         ## get overall call statistics
         call_stats <-
@@ -277,32 +294,45 @@ generate_cpsr_report <- function(project_directory = NULL,
         calls <- dplyr::mutate(calls, SYMBOL = as.character(.data$SYMBOL))
         cpg_calls <-
           dplyr::inner_join(calls,
-                            cps_report[["metadata"]][["gene_panel"]][["genes"]],
-                            by = c("SYMBOL" = "symbol"))
+            cps_report[["metadata"]][["gene_panel"]][["genes"]],
+            by = c("SYMBOL" = "symbol")
+          )
         cpg_call_stats <-
           pcgrr::variant_stats_report(
-            cpg_calls, name = "v_stat_cpg")
+            cpg_calls,
+            name = "v_stat_cpg"
+          )
 
         pcgrr::log4r_info(
-          paste0("Total number of variants in target cancer predisposition genes (for TIER output): ",
-                 cpg_call_stats[["v_stat_cpg"]][["n"]]))
+          paste0(
+            "Total number of variants in target cancer predisposition genes (for TIER output): ",
+            cpg_call_stats[["v_stat_cpg"]][["n"]]
+          )
+        )
         pcgrr::log4r_info(
-          paste0("Number of coding variants in target cancer predisposition genes (for TIER output): ",
-                 cpg_call_stats[["v_stat_cpg"]][["n_coding"]]))
+          paste0(
+            "Number of coding variants in target cancer predisposition genes (for TIER output): ",
+            cpg_call_stats[["v_stat_cpg"]][["n_coding"]]
+          )
+        )
         pcgrr::log4r_info(
           paste0(
             "Number of non-coding variants in cancer predisposition genes (for TIER output): ",
-            cpg_call_stats[["v_stat_cpg"]][["n_noncoding"]]))
+            cpg_call_stats[["v_stat_cpg"]][["n_noncoding"]]
+          )
+        )
 
 
         ## Get secondary variant calls
         secondary_calls <-
           retrieve_secondary_calls(
             calls,
-            umls_map = pcgr_data$phenotype_ontology$umls)
+            umls_map = pcgr_data$phenotype_ontology$umls
+          )
         secondary_call_stats <-
           pcgrr::variant_stats_report(secondary_calls,
-                                      name = "v_stat_secondary")
+            name = "v_stat_secondary"
+          )
 
         if (nrow(cpg_calls) == 0) {
           cps_report$content$snv_indel$v_stat_cpg <-
@@ -313,26 +343,30 @@ generate_cpsr_report <- function(project_directory = NULL,
         ## Assign ACMG evidence codes (>30 criteria) to variants
         cpg_calls <-
           assign_pathogenicity_evidence(
-            cpg_calls, cpsr_config, pcgr_data) %>%
+            cpg_calls, cpsr_config, pcgr_data
+          ) %>%
           determine_pathogenicity_classification() %>%
           detect_cancer_traits_clinvar(
             oncotree =
               cps_report[["metadata"]][["phenotype_ontology"]][["oncotree"]],
             umls_map =
-              pcgr_data[["phenotype_ontology"]][["umls"]])
+              pcgr_data[["phenotype_ontology"]][["umls"]]
+          )
 
-        if (cpsr_config[['clinvar_ignore_noncancer']] == T &
-           "VAR_ID" %in% colnames(cpg_calls) &
-           "CLINVAR_MSID" %in% colnames(cpg_calls) &
-           "CANCER_PHENOTYPE" %in% colnames(cpg_calls)) {
+        if (cpsr_config[["clinvar_ignore_noncancer"]] == T &
+          "VAR_ID" %in% colnames(cpg_calls) &
+          "CLINVAR_MSID" %in% colnames(cpg_calls) &
+          "CANCER_PHENOTYPE" %in% colnames(cpg_calls)) {
           n_clinvar_noncancer <- cpg_calls %>%
             dplyr::filter(!is.na(.data$CLINVAR_MSID)) %>%
             dplyr::filter(.data$CANCER_PHENOTYPE == 0) %>%
             NROW()
 
           pcgrr::log4r_info(
-            paste0("ClinVar variants related to non-cancer conditions excluded",
-            " from report: ", n_clinvar_noncancer)
+            paste0(
+              "ClinVar variants related to non-cancer conditions excluded",
+              " from report: ", n_clinvar_noncancer
+            )
           )
 
           if (n_clinvar_noncancer > 0) {
@@ -345,9 +379,11 @@ generate_cpsr_report <- function(project_directory = NULL,
               dplyr::anti_join(cpg_calls_exclude, by = "VAR_ID")
 
             pcgrr::log4r_info(
-              paste0("Variants remaining after exclusion of non-cancer related",
-              " ClinVar variants: ", NROW(cpg_calls)))
-
+              paste0(
+                "Variants remaining after exclusion of non-cancer related",
+                " ClinVar variants: ", NROW(cpg_calls)
+              )
+            )
           }
         }
 
@@ -364,7 +400,8 @@ generate_cpsr_report <- function(project_directory = NULL,
             cpg_calls,
             config = cps_report[["metadata"]][["config"]],
             cpsr_display_cols = cpsr_tier_display_cols,
-            cpsr_tsv_cols = cpsr_tsv_cols)
+            cpsr_tsv_cols = cpsr_tsv_cols
+          )
 
         snv_indel_report$v_stat <-
           call_stats$v_stat
@@ -380,27 +417,35 @@ generate_cpsr_report <- function(project_directory = NULL,
         eitems_mut_germline <- pcgrr::load_all_eitems(
           eitems_raw = pcgr_data$biomarkers,
           alteration_type = "MUT",
-          origin = "Germline")
+          origin = "Germline"
+        )
 
         eitems_mut_lof_germline <- pcgrr::load_all_eitems(
           eitems_raw = pcgr_data$biomarkers,
           alteration_type = "MUT_LOF",
-          origin = "Germline")
+          origin = "Germline"
+        )
 
-        eitems_all <- dplyr::bind_rows(eitems_mut_germline,
-                                       eitems_mut_lof_germline) %>%
+        eitems_all <- dplyr::bind_rows(
+          eitems_mut_germline,
+          eitems_mut_lof_germline
+        ) %>%
           pcgrr::remove_cols_from_df(
-            cnames = c("DISEASE_ONTOLOGY_ID",
-                       "VARIANT_ORIGIN",
-                       "VARIANT_TYPE",
-                       "ACTIONABILITY_SCORE")) %>%
+            cnames = c(
+              "DISEASE_ONTOLOGY_ID",
+              "VARIANT_ORIGIN",
+              "VARIANT_TYPE",
+              "ACTIONABILITY_SCORE"
+            )
+          ) %>%
           dplyr::distinct()
 
         snv_indel_report$clin_eitem <-
           get_germline_biomarkers(
             sample_calls = snv_indel_report[["variant_set"]][["tsv"]],
             colset = colnames(snv_indel_report[["variant_set"]][["tsv"]]),
-            eitems = eitems_all)
+            eitems = eitems_all
+          )
 
         cps_report <-
           pcgrr::update_report(cps_report, report_data = snv_indel_report)
@@ -408,55 +453,66 @@ generate_cpsr_report <- function(project_directory = NULL,
         cps_report[["content"]][["snv_indel"]][["variant_set"]][["tsv"]] <-
           cps_report[["content"]][["snv_indel"]][["variant_set"]][["tsv"]] %>%
           pcgrr::remove_cols_from_df(
-            cnames = c("CIVIC_ID",
-                       "CIVIC_ID_SEGMENT",
-                       "AMINO_ACID_END",
-                       "AMINO_ACID_START",
-                       "EXON"))
+            cnames = c(
+              "CIVIC_ID",
+              "CIVIC_ID_SEGMENT",
+              "AMINO_ACID_END",
+              "AMINO_ACID_START",
+              "EXON"
+            )
+          )
 
         gene_hits <- paste(
           unique(
-            cps_report[["content"]][["snv_indel"]][["variant_set"]][["tsv"]]$SYMBOL),
-          collapse = ", ")
-        pcgrr::log4r_info(paste0("Variants were found in the following cancer ",
-                          "predisposition genes: ", gene_hits))
+            cps_report[["content"]][["snv_indel"]][["variant_set"]][["tsv"]]$SYMBOL
+          ),
+          collapse = ", "
+        )
+        pcgrr::log4r_info(paste0(
+          "Variants were found in the following cancer ",
+          "predisposition genes: ", gene_hits
+        ))
 
         ## secondary findings
         if (cpsr_config[["secondary_findings"]] == TRUE) {
-          pcgrr::log4r_info(paste0("Assignment of other variants in genes ",
-                                   "recommended for reporting as secondary ",
-                                   "findings (ACMG SF v3.0)"))
+          pcgrr::log4r_info(paste0(
+            "Assignment of other variants in genes ",
+            "recommended for reporting as secondary ",
+            "findings (ACMG SF v3.0)"
+          ))
           if (nrow(secondary_calls) > 0) {
             cps_report[["content"]][["snv_indel"]][["disp"]][["secondary"]] <-
               secondary_calls %>%
               dplyr::arrange(.data$LOSS_OF_FUNCTION, .data$CODING_STATUS) %>%
               dplyr::select(dplyr::one_of(cpsr_sf_display_cols))
-
           }
           pcgrr::log4r_info(paste0(
             "Number of pathogenic variants in the ACMG secondary findings list - other ",
             "genes of clinical significance: ",
-            cps_report[["content"]][["snv_indel"]][["v_stat_secondary"]][["n_coding"]]))
+            cps_report[["content"]][["snv_indel"]][["v_stat_secondary"]][["n_coding"]]
+          ))
         }
 
         cps_report[["content"]][["snv_indel"]][["eval"]] <- TRUE
 
         if (cpsr_config[["gwas"]][["run"]] == TRUE) {
-            pcgrr::log4r_info(paste0("Assignment of other variants to hits ",
-                            "from genome-wide association studies"))
+          pcgrr::log4r_info(paste0(
+            "Assignment of other variants to hits ",
+            "from genome-wide association studies"
+          ))
 
           ## Assign GWAS hits to cps_report object
           cps_report[["content"]][["snv_indel"]][["disp"]][["gwas"]] <-
             dplyr::filter(calls, !is.na(.data$GWAS_HIT) & !is.na(.data$GWAS_CITATION))
           if (nrow(cps_report[["content"]][["snv_indel"]][["disp"]][["gwas"]]) > 0) {
             if (nrow(cps_report[["content"]][["snv_indel"]][["variant_set"]][["tsv"]]) > 0) {
-
               ## Omit variants that is already present in TIER 1-5
               cps_report[["content"]][["snv_indel"]][["disp"]][["gwas"]] <-
                 dplyr::anti_join(
                   cps_report[["content"]][["snv_indel"]][["disp"]][["gwas"]],
                   cps_report[["content"]][["snv_indel"]][["variant_set"]][["tsv"]],
-                  by = c("GENOMIC_CHANGE"))
+                  by = c("GENOMIC_CHANGE")
+                )
             }
             ## Select variables to include for GWAS hits and arrange results
             if (nrow(cps_report[["content"]][["snv_indel"]][["disp"]][["gwas"]]) > 0) {
@@ -471,7 +527,7 @@ generate_cpsr_report <- function(project_directory = NULL,
     }
   }
 
-  cps_report[["content"]][["snv_indel"]][['max_dt_rows']] <-
+  cps_report[["content"]][["snv_indel"]][["max_dt_rows"]] <-
     get_max_rows_pr_datatable(cps_report)
 
   return(cps_report)
@@ -487,11 +543,12 @@ generate_cpsr_report <- function(project_directory = NULL,
 #'
 #' @export
 get_max_rows_pr_datatable <- function(cps_report) {
-
   max_row_nr <- 0
   if (!is.null(cps_report[["content"]][["snv_indel"]][["disp"]])) {
-    for(c in c("class1", "class2", "class3",
-               "class4", "class5", "sf", "gwas")) {
+    for (c in c(
+      "class1", "class2", "class3",
+      "class4", "class5", "sf", "gwas"
+    )) {
       if (NROW(cps_report[["content"]][["snv_indel"]][["disp"]][[c]]) == 0) {
         next
       }
@@ -500,7 +557,7 @@ get_max_rows_pr_datatable <- function(cps_report) {
         if (nrow(t1) > max_row_nr) {
           max_row_nr <- nrow(t1)
         }
-      }else{
+      } else {
         t1 <- cps_report[["content"]][["snv_indel"]][["disp"]][[c]]
         num_rows_clinvar <- t1 %>%
           dplyr::filter(.data$CPSR_CLASSIFICATION_SOURCE == "ClinVar") %>%
@@ -529,52 +586,71 @@ get_max_rows_pr_datatable <- function(cps_report) {
 #'
 #' @export
 get_insilico_prediction_statistics <- function(cpg_calls) {
-
   insilico_pathogenicity_pred_algos <-
-    c("DBNSFP_SIFT", "DBNSFP_PROVEAN",
+    c(
+      "DBNSFP_SIFT", "DBNSFP_PROVEAN",
       "DBNSFP_META_RNN", "DBNSFP_FATHMM",
       "DBNSFP_MUTATIONTASTER", "DBNSFP_DEOGEN2",
       "DBNSFP_PRIMATEAI", "DBNSFP_MUTATIONASSESSOR",
       "DBNSFP_FATHMM_MKL", "DBNSFP_M_CAP",
       "DBNSFP_LIST_S2", "DBNSFP_BAYESDEL_ADDAF",
-      "DBNSFP_SPLICE_SITE_ADA", "DBNSFP_SPLICE_SITE_RF")
-  for (v in c("CALLED", "DAMAGING", "TOLERATED",
-              "SPLICING_NEUTRAL", "SPLICING_AFFECTED")) {
+      "DBNSFP_SPLICE_SITE_ADA", "DBNSFP_SPLICE_SITE_RF"
+    )
+  for (v in c(
+    "CALLED", "DAMAGING", "TOLERATED",
+    "SPLICING_NEUTRAL", "SPLICING_AFFECTED"
+  )) {
     cpg_calls[, paste0("N_INSILICO_", v)] <- 0
   }
 
   for (algo in insilico_pathogenicity_pred_algos) {
     if (algo %in% colnames(cpg_calls)) {
       cpg_calls[!is.na(cpg_calls[, algo]) &
-                  cpg_calls[, algo] != ".", "N_INSILICO_CALLED"] <-
+        cpg_calls[, algo] != ".", "N_INSILICO_CALLED"] <-
         cpg_calls[!is.na(cpg_calls[, algo]) &
-                    cpg_calls[, algo] != ".", "N_INSILICO_CALLED"] + 1
-      cpg_calls[!is.na(cpg_calls[, algo]) &
-                  (cpg_calls[, algo] == "D" |
-                     cpg_calls[, algo] == "PD"),
-                "N_INSILICO_DAMAGING"] <-
-        cpg_calls[!is.na(cpg_calls[, algo]) &
-                    (cpg_calls[, algo] == "D" |
-                       cpg_calls[, algo] == "PD"),
-                  "N_INSILICO_DAMAGING"] + 1
-      cpg_calls[!is.na(cpg_calls[, algo]) &
-                  cpg_calls[, algo] == "T",
-                "N_INSILICO_TOLERATED"] <-
-        cpg_calls[!is.na(cpg_calls[, algo]) &
-                    cpg_calls[, algo] == "T",
-                  "N_INSILICO_TOLERATED"] + 1
-      cpg_calls[!is.na(cpg_calls[, algo]) &
-                  cpg_calls[, algo] == "AS",
-                "N_INSILICO_SPLICING_AFFECTED"] <-
-        cpg_calls[!is.na(cpg_calls[, algo]) &
-                    cpg_calls[, algo] == "AS",
-                  "N_INSILICO_SPLICING_AFFECTED"] + 1
-      cpg_calls[!is.na(cpg_calls[, algo]) &
-                  cpg_calls[, algo] == "SN",
-                "N_INSILICO_SPLICING_NEUTRAL"] <-
-        cpg_calls[!is.na(cpg_calls[, algo]) &
-                    cpg_calls[, algo] == "SN",
-                  "N_INSILICO_SPLICING_NEUTRAL"] + 1
+          cpg_calls[, algo] != ".", "N_INSILICO_CALLED"] + 1
+      cpg_calls[
+        !is.na(cpg_calls[, algo]) &
+          (cpg_calls[, algo] == "D" |
+            cpg_calls[, algo] == "PD"),
+        "N_INSILICO_DAMAGING"
+      ] <-
+        cpg_calls[
+          !is.na(cpg_calls[, algo]) &
+            (cpg_calls[, algo] == "D" |
+              cpg_calls[, algo] == "PD"),
+          "N_INSILICO_DAMAGING"
+        ] + 1
+      cpg_calls[
+        !is.na(cpg_calls[, algo]) &
+          cpg_calls[, algo] == "T",
+        "N_INSILICO_TOLERATED"
+      ] <-
+        cpg_calls[
+          !is.na(cpg_calls[, algo]) &
+            cpg_calls[, algo] == "T",
+          "N_INSILICO_TOLERATED"
+        ] + 1
+      cpg_calls[
+        !is.na(cpg_calls[, algo]) &
+          cpg_calls[, algo] == "AS",
+        "N_INSILICO_SPLICING_AFFECTED"
+      ] <-
+        cpg_calls[
+          !is.na(cpg_calls[, algo]) &
+            cpg_calls[, algo] == "AS",
+          "N_INSILICO_SPLICING_AFFECTED"
+        ] + 1
+      cpg_calls[
+        !is.na(cpg_calls[, algo]) &
+          cpg_calls[, algo] == "SN",
+        "N_INSILICO_SPLICING_NEUTRAL"
+      ] <-
+        cpg_calls[
+          !is.na(cpg_calls[, algo]) &
+            cpg_calls[, algo] == "SN",
+          "N_INSILICO_SPLICING_NEUTRAL"
+        ] + 1
     }
   }
   return(cpg_calls)
@@ -590,19 +666,19 @@ get_insilico_prediction_statistics <- function(cpg_calls) {
 #'
 #' @export
 assign_pathogenicity_evidence <- function(cpg_calls, cpsr_config, pcgr_data) {
-
   gad_population <- toupper(cpsr_config[["popgen"]][["pop_gnomad"]])
   gad_AN_tag <- paste0("NON_CANCER_AN_", gad_population)
   gad_AF_tag <- paste0("NON_CANCER_AF_", gad_population)
   gad_NHOMALT_tag <- paste0("NON_CANCER_NHOMALT_", gad_population)
   gad_AC_tag <- paste0("NON_CANCER_AC_", gad_population)
 
-  #pathogenic_range_ac <- 20
+  # pathogenic_range_ac <- 20
   pathogenic_range_af <- pcgrr::cpsr_acmg[["pathogenic_range_gnomad"]][["af"]]
   min_an <- pcgrr::cpsr_acmg[["pathogenic_range_gnomad"]][["min_an"]]
 
   acmg_ev_codes <-
-    c("ACMG_BA1_AD",
+    c(
+      "ACMG_BA1_AD",
       ## Very high MAF (> 0.5% in gnomAD non-cancer pop subset) -
       ## min AN = 12,000, - Dominant mechanism of disease
       "ACMG_BS1_1_AD",
@@ -620,13 +696,13 @@ assign_pathogenicity_evidence <- function(cpg_calls, cpsr_config, pcgr_data) {
       "ACMG_BS1_2_AR",
       ## Somewhat high MAF (> 0.005% in gnomAD non-cancer pop subset) -
       ## min AN = 12,000 - Recessive mechanism of disease
-      #"ACMG_BS2_1",
+      # "ACMG_BS2_1",
       ## 1 homozygote in gnomAD non-cancer pop subset -
       ## severe, early onset, highly penetrant
-      #"ACMG_BS2_2",
+      # "ACMG_BS2_2",
       ## 2 homozygotes in gnomAD non-cancer pop subset -
       ## severe, early onset, highly penetrant
-      #"ACMG_BS2_3",
+      # "ACMG_BS2_3",
       ## 2 homozygotes in gnomAD non-cancer pop subset -
       ## moderate, early onset, variably penetrant
       "ACMG_PM2_1",
@@ -701,48 +777,65 @@ assign_pathogenicity_evidence <- function(cpg_calls, cpsr_config, pcgr_data) {
       ## Variants in promoter or untranslated regions
       "ACMG_BP7",
       ## Silent/intronic variant outside of the splice site consensus
-      "ACMG_BP1")
-       ## Missense variant in a gene for which primarily truncating
-       ##variants are known to cause disease (ClinVar)
+      "ACMG_BP1"
+    )
+  ## Missense variant in a gene for which primarily truncating
+  ## variants are known to cause disease (ClinVar)
 
 
-    path_columns <-
-      c(acmg_ev_codes, "N_INSILICO_CALLED",
-        "N_INSILICO_DAMAGING", "N_INSILICO_TOLERATED",
-        "N_INSILICO_SPLICING_NEUTRAL",
-        "N_INSILICO_SPLICING_AFFECTED", "codon_prefix",
-        "clinvar_pathogenic_codon",
-        "clinvar_pathogenic", "clinvar_benign",
-        "clinvar_benign_codon", "hotspot_symbol",
-        "hotspot_codon", "hotspot_pvalue",
-        "MOD", "PATH_TRUNCATION_RATE", "BENIGN_MISSENSE_RATE")
+  path_columns <-
+    c(
+      acmg_ev_codes, "N_INSILICO_CALLED",
+      "N_INSILICO_DAMAGING", "N_INSILICO_TOLERATED",
+      "N_INSILICO_SPLICING_NEUTRAL",
+      "N_INSILICO_SPLICING_AFFECTED", "codon_prefix",
+      "clinvar_pathogenic_codon",
+      "clinvar_pathogenic", "clinvar_benign",
+      "clinvar_benign_codon", "hotspot_symbol",
+      "hotspot_codon", "hotspot_pvalue",
+      "MOD", "PATH_TRUNCATION_RATE", "BENIGN_MISSENSE_RATE"
+    )
   cpg_calls <- cpg_calls[, !(colnames(cpg_calls) %in% path_columns)]
 
 
   cpg_calls <- cpg_calls %>%
     dplyr::mutate(
       cpsr_gene_moi =
-        dplyr::if_else(stringr::str_detect(.data$CANCER_PREDISPOSITION_MOI,
-                                           "AD|AD/AR"),
-                       "AD", as.character(NA), as.character(NA))) %>%
+        dplyr::if_else(stringr::str_detect(
+          .data$CANCER_PREDISPOSITION_MOI,
+          "AD|AD/AR"
+        ),
+        "AD", as.character(NA), as.character(NA)
+        )
+    ) %>%
     dplyr::mutate(
       cpsr_gene_moi =
-        dplyr::if_else(!stringr::str_detect(.data$CANCER_PREDISPOSITION_MOI,
-                                            "AD|Mosaic"),
-                       "AR", .data$cpsr_gene_moi, .data$cpsr_gene_moi))
+        dplyr::if_else(!stringr::str_detect(
+          .data$CANCER_PREDISPOSITION_MOI,
+          "AD|Mosaic"
+        ),
+        "AR", .data$cpsr_gene_moi, .data$cpsr_gene_moi
+        )
+    )
 
   predisposition_gene_info <-
-    dplyr::select(pcgr_data[["predisposition"]][["genes"]], .data$symbol,
-                  .data$cancer_predisposition_mod, .data$path_truncation_rate,
-                  .data$benign_missense_rate) %>%
-    dplyr::rename(SYMBOL = .data$symbol,
-                  MOD = .data$cancer_predisposition_mod,
-                  PATH_TRUNCATION_RATE = .data$path_truncation_rate,
-                  BENIGN_MISSENSE_RATE = .data$benign_missense_rate)
+    dplyr::select(
+      pcgr_data[["predisposition"]][["genes"]], .data$symbol,
+      .data$cancer_predisposition_mod, .data$path_truncation_rate,
+      .data$benign_missense_rate
+    ) %>%
+    dplyr::rename(
+      SYMBOL = .data$symbol,
+      MOD = .data$cancer_predisposition_mod,
+      PATH_TRUNCATION_RATE = .data$path_truncation_rate,
+      BENIGN_MISSENSE_RATE = .data$benign_missense_rate
+    )
 
   cpg_calls <-
     dplyr::left_join(cpg_calls,
-                     predisposition_gene_info, by = c("SYMBOL" = "SYMBOL"))
+      predisposition_gene_info,
+      by = c("SYMBOL" = "SYMBOL")
+    )
 
   ## Assign logical ACMG evidence indicators
   #
@@ -781,18 +874,23 @@ assign_pathogenicity_evidence <- function(cpg_calls, cpsr_config, pcgr_data) {
     dplyr::mutate(
       ACMG_PP3 =
         dplyr::if_else(.data$N_INSILICO_CALLED >= dbnsfp_min_called &
-                         .data$N_INSILICO_DAMAGING >= dbnsfp_min_majority &
-                         .data$N_INSILICO_TOLERATED <= dbnsfp_max_minority &
-                         .data$N_INSILICO_SPLICING_NEUTRAL <= 1, TRUE,
-                       FALSE, FALSE)) %>%
+          .data$N_INSILICO_DAMAGING >= dbnsfp_min_majority &
+          .data$N_INSILICO_TOLERATED <= dbnsfp_max_minority &
+          .data$N_INSILICO_SPLICING_NEUTRAL <= 1, TRUE,
+        FALSE, FALSE
+        )
+    ) %>%
     dplyr::mutate(
       ACMG_BP4 = dplyr::if_else(.data$N_INSILICO_CALLED >= dbnsfp_min_called &
-                                  .data$N_INSILICO_TOLERATED >= dbnsfp_min_majority &
-                                  .data$N_INSILICO_DAMAGING <= dbnsfp_max_minority &
-                                  .data$N_INSILICO_SPLICING_AFFECTED == 0, TRUE,
-                                FALSE, FALSE)) %>%
+        .data$N_INSILICO_TOLERATED >= dbnsfp_min_majority &
+        .data$N_INSILICO_DAMAGING <= dbnsfp_max_minority &
+        .data$N_INSILICO_SPLICING_AFFECTED == 0, TRUE,
+      FALSE, FALSE
+      )
+    ) %>%
     dplyr::mutate(ACMG_PP3 = dplyr::case_when(
-      .data$N_INSILICO_SPLICING_AFFECTED == 2 ~ TRUE, TRUE ~ as.logical(.data$ACMG_PP3)))
+      .data$N_INSILICO_SPLICING_AFFECTED == 2 ~ TRUE, TRUE ~ as.logical(.data$ACMG_PP3)
+    ))
 
   ## Assign logical ACMG evidence indicators based on population frequency
   ## data in non-cancer samples from gnomAD (Dominant vs. recessive
@@ -815,9 +913,8 @@ assign_pathogenicity_evidence <- function(cpg_calls, cpsr_config, pcgr_data) {
   # 'ACMG_PM2_2'    - Alternate allele absent in the population-specific
   #                   non-cancer gnomAD subset
   if (gad_AN_tag %in% colnames(cpg_calls) &
-      gad_AC_tag %in% colnames(cpg_calls) &
-      gad_NHOMALT_tag %in% colnames(cpg_calls)) {
-
+    gad_AC_tag %in% colnames(cpg_calls) &
+    gad_NHOMALT_tag %in% colnames(cpg_calls)) {
     # cpg_calls2 <- cpg_calls %>%
     #   dplyr::mutate(!!rlang::sym(gad_AN_tag) := as.double(!!rlang::sym(gad_AN_tag))) %>%
     #   dplyr::mutate(!!rlang::sym(gad_AC_tag) := as.double(!!rlang::sym(gad_AC_tag))) %>%
@@ -827,57 +924,75 @@ assign_pathogenicity_evidence <- function(cpg_calls, cpsr_config, pcgr_data) {
       dplyr::mutate(
         gad_af =
           dplyr::if_else(!!rlang::sym(gad_AN_tag) >= min_an,
-                         as.double(!!rlang::sym(gad_AC_tag) /
-                                      !!rlang::sym(gad_AN_tag)),
-                         as.double(NA), as.double(NA))) %>%
+            as.double(!!rlang::sym(gad_AC_tag) /
+              !!rlang::sym(gad_AN_tag)),
+            as.double(NA), as.double(NA)
+          )
+      ) %>%
       dplyr::mutate(
         ACMG_PM2_1 =
           dplyr::if_else(!!rlang::sym(gad_AN_tag) >= min_an &
-                           !is.na(!!rlang::sym(gad_AC_tag)) &
-                           .data$gad_af <= pathogenic_range_af,
-                         TRUE, FALSE, FALSE)) %>%
+            !is.na(!!rlang::sym(gad_AC_tag)) &
+            .data$gad_af <= pathogenic_range_af,
+          TRUE, FALSE, FALSE
+          )
+      ) %>%
       dplyr::mutate(
         ACMG_PM2_2 = dplyr::if_else(is.na(!!rlang::sym(gad_AC_tag)),
-                                    TRUE, FALSE, FALSE)) %>%
+          TRUE, FALSE, FALSE
+        )
+      ) %>%
       dplyr::mutate(
         ACMG_BA1_AD = dplyr::if_else(.data$ACMG_PM2_2 == FALSE &
-                                       .data$gad_af >= 0.005 &
-                                       .data$cpsr_gene_moi == "AD",
-                                     TRUE, FALSE, FALSE)) %>%
+          .data$gad_af >= 0.005 &
+          .data$cpsr_gene_moi == "AD",
+        TRUE, FALSE, FALSE
+        )
+      ) %>%
       dplyr::mutate(
         ACMG_BS1_1_AD = dplyr::if_else(.data$ACMG_BA1_AD == FALSE &
-                                         .data$ACMG_PM2_2 == FALSE &
-                                         .data$gad_af >= 0.001 &
-                                         .data$cpsr_gene_moi == "AD",
-                                       TRUE, FALSE, FALSE)) %>%
+          .data$ACMG_PM2_2 == FALSE &
+          .data$gad_af >= 0.001 &
+          .data$cpsr_gene_moi == "AD",
+        TRUE, FALSE, FALSE
+        )
+      ) %>%
       dplyr::mutate(
         ACMG_BS1_2_AD = dplyr::if_else(.data$ACMG_BS1_1_AD == FALSE &
-                                         .data$ACMG_BA1_AD == FALSE &
-                                         .data$ACMG_PM2_2 == FALSE &
-                                         .data$gad_af > pathogenic_range_af &
-                                         .data$cpsr_gene_moi == "AD",
-                                       TRUE, FALSE, FALSE)) %>%
+          .data$ACMG_BA1_AD == FALSE &
+          .data$ACMG_PM2_2 == FALSE &
+          .data$gad_af > pathogenic_range_af &
+          .data$cpsr_gene_moi == "AD",
+        TRUE, FALSE, FALSE
+        )
+      ) %>%
       dplyr::mutate(
         ACMG_BA1_AR = dplyr::if_else(.data$ACMG_PM2_2 == FALSE &
-                                       .data$gad_af >= 0.01 &
-                                       (.data$cpsr_gene_moi == "AR" |
-                                          is.na(.data$cpsr_gene_moi)),
-                                     TRUE, FALSE, FALSE)) %>%
+          .data$gad_af >= 0.01 &
+          (.data$cpsr_gene_moi == "AR" |
+            is.na(.data$cpsr_gene_moi)),
+        TRUE, FALSE, FALSE
+        )
+      ) %>%
       dplyr::mutate(
         ACMG_BS1_1_AR = dplyr::if_else(.data$ACMG_BA1_AR == FALSE &
-                                         .data$ACMG_PM2_2 == FALSE &
-                                         .data$gad_af >= 0.003 &
-                                         (.data$cpsr_gene_moi == "AR" |
-                                            is.na(.data$cpsr_gene_moi)),
-                                       TRUE, FALSE, FALSE)) %>%
+          .data$ACMG_PM2_2 == FALSE &
+          .data$gad_af >= 0.003 &
+          (.data$cpsr_gene_moi == "AR" |
+            is.na(.data$cpsr_gene_moi)),
+        TRUE, FALSE, FALSE
+        )
+      ) %>%
       dplyr::mutate(
         ACMG_BS1_2_AR = dplyr::if_else(.data$ACMG_BA1_AR == FALSE &
-                                         .data$ACMG_BS1_1_AR == FALSE &
-                                         .data$ACMG_PM2_2 == FALSE &
-                                         .data$gad_af > pathogenic_range_af &
-                                         (.data$cpsr_gene_moi == "AR" |
-                                            is.na(.data$cpsr_gene_moi)),
-                                       TRUE, FALSE, FALSE))
+          .data$ACMG_BS1_1_AR == FALSE &
+          .data$ACMG_PM2_2 == FALSE &
+          .data$gad_af > pathogenic_range_af &
+          (.data$cpsr_gene_moi == "AR" |
+            is.na(.data$cpsr_gene_moi)),
+        TRUE, FALSE, FALSE
+        )
+      )
   }
 
   ## Assign logical ACMG evidence indicators on NULL variants in known
@@ -908,64 +1023,84 @@ assign_pathogenicity_evidence <- function(cpg_calls, cpsr_config, pcgr_data) {
     dplyr::mutate(
       ACMG_PVS1_1 =
         dplyr::if_else(.data$NULL_VARIANT == T & .data$LOSS_OF_FUNCTION == T &
-                         .data$MOD == "LoF" &
-                         (.data$ACMG_PM2_1 == TRUE | .data$ACMG_PM2_2 == TRUE),
-                       TRUE, FALSE, FALSE)) %>%
+          .data$MOD == "LoF" &
+          (.data$ACMG_PM2_1 == TRUE | .data$ACMG_PM2_2 == TRUE),
+        TRUE, FALSE, FALSE
+        )
+    ) %>%
     dplyr::mutate(
       ACMG_PVS1_3 =
         dplyr::if_else(.data$NULL_VARIANT == T & .data$LOSS_OF_FUNCTION == T &
-                         (is.na(.data$MOD) | .data$MOD != "LoF") &
-                         (.data$ACMG_PM2_1 == TRUE | .data$ACMG_PM2_2 == TRUE),
-                       TRUE, FALSE, FALSE)) %>%
+          (is.na(.data$MOD) | .data$MOD != "LoF") &
+          (.data$ACMG_PM2_1 == TRUE | .data$ACMG_PM2_2 == TRUE),
+        TRUE, FALSE, FALSE
+        )
+    ) %>%
     dplyr::mutate(
       ACMG_PVS1_2 =
         dplyr::if_else(.data$NULL_VARIANT == T & .data$LOSS_OF_FUNCTION == F &
-                         .data$MOD == "LoF" &
-                         (.data$ACMG_PM2_1 == TRUE | .data$ACMG_PM2_2 == TRUE),
-                       TRUE, FALSE, FALSE)) %>%
+          .data$MOD == "LoF" &
+          (.data$ACMG_PM2_1 == TRUE | .data$ACMG_PM2_2 == TRUE),
+        TRUE, FALSE, FALSE
+        )
+    ) %>%
     dplyr::mutate(
       ACMG_PVS1_4 =
         dplyr::if_else(.data$NULL_VARIANT == T & .data$LOSS_OF_FUNCTION == F &
-                         (is.na(.data$MOD) | .data$MOD != "LoF") &
-                         (.data$ACMG_PM2_1 == TRUE | .data$ACMG_PM2_2 == TRUE),
-                       TRUE, FALSE, FALSE)) %>%
+          (is.na(.data$MOD) | .data$MOD != "LoF") &
+          (.data$ACMG_PM2_1 == TRUE | .data$ACMG_PM2_2 == TRUE),
+        TRUE, FALSE, FALSE
+        )
+    ) %>%
     dplyr::mutate(
       ACMG_PVS1_5 =
         dplyr::if_else(.data$CONSEQUENCE == "start_lost" & .data$MOD == "LoF" &
-                         (.data$ACMG_PM2_1 == TRUE | .data$ACMG_PM2_2 == TRUE),
-                       TRUE, FALSE, FALSE)) %>%
+          (.data$ACMG_PM2_1 == TRUE | .data$ACMG_PM2_2 == TRUE),
+        TRUE, FALSE, FALSE
+        )
+    ) %>%
     dplyr::mutate(
       ACMG_PVS1_6 =
         dplyr::if_else(.data$CONSEQUENCE == "start_lost" & (is.na(.data$MOD) |
-                                                        .data$MOD != "LoF") &
-                         (.data$ACMG_PM2_1 == TRUE | .data$ACMG_PM2_2 == TRUE),
-                       TRUE, FALSE, FALSE)) %>%
+          .data$MOD != "LoF") &
+          (.data$ACMG_PM2_1 == TRUE | .data$ACMG_PM2_2 == TRUE),
+        TRUE, FALSE, FALSE
+        )
+    ) %>%
     dplyr::mutate(
       ACMG_PVS1_7 =
         dplyr::if_else(.data$LOSS_OF_FUNCTION == T &
-                         stringr::str_detect(.data$CONSEQUENCE, "_donor|_acceptor") &
-                         .data$LAST_INTRON == F & .data$MOD == "LoF" &
-                         (.data$ACMG_PM2_1 == TRUE | .data$ACMG_PM2_2 == TRUE),
-                       TRUE, FALSE, FALSE)) %>%
+          stringr::str_detect(.data$CONSEQUENCE, "_donor|_acceptor") &
+          .data$LAST_INTRON == F & .data$MOD == "LoF" &
+          (.data$ACMG_PM2_1 == TRUE | .data$ACMG_PM2_2 == TRUE),
+        TRUE, FALSE, FALSE
+        )
+    ) %>%
     dplyr::mutate(
       ACMG_PVS1_8 =
         dplyr::if_else(.data$LOSS_OF_FUNCTION == T &
-                         stringr::str_detect(.data$CONSEQUENCE, "_donor|_acceptor") &
-                         .data$LAST_INTRON == T & .data$MOD == "LoF" &
-                         (.data$ACMG_PM2_1 == TRUE | .data$ACMG_PM2_2 == TRUE),
-                       TRUE, FALSE, FALSE)) %>%
+          stringr::str_detect(.data$CONSEQUENCE, "_donor|_acceptor") &
+          .data$LAST_INTRON == T & .data$MOD == "LoF" &
+          (.data$ACMG_PM2_1 == TRUE | .data$ACMG_PM2_2 == TRUE),
+        TRUE, FALSE, FALSE
+        )
+    ) %>%
     dplyr::mutate(
       ACMG_PVS1_9 =
         dplyr::if_else(.data$LOSS_OF_FUNCTION == T &
-                         stringr::str_detect(.data$CONSEQUENCE, "_donor|_acceptor") &
-                         .data$LAST_INTRON == F & (is.na(.data$MOD) | .data$MOD != "LoF") &
-                         (.data$ACMG_PM2_1 == TRUE | .data$ACMG_PM2_2 == TRUE),
-                       TRUE, FALSE, FALSE)) %>%
+          stringr::str_detect(.data$CONSEQUENCE, "_donor|_acceptor") &
+          .data$LAST_INTRON == F & (is.na(.data$MOD) | .data$MOD != "LoF") &
+          (.data$ACMG_PM2_1 == TRUE | .data$ACMG_PM2_2 == TRUE),
+        TRUE, FALSE, FALSE
+        )
+    ) %>%
     dplyr::mutate(
       ACMG_PVS1_10 =
         dplyr::if_else(.data$SPLICE_DONOR_RELEVANT == T & .data$ACMG_PP3 == TRUE &
-                         (.data$ACMG_PM2_1 == TRUE | .data$ACMG_PM2_2 == TRUE),
-                       TRUE, FALSE,  FALSE))
+          (.data$ACMG_PM2_1 == TRUE | .data$ACMG_PM2_2 == TRUE),
+        TRUE, FALSE, FALSE
+        )
+    )
 
 
 
@@ -987,16 +1122,22 @@ assign_pathogenicity_evidence <- function(cpg_calls, cpsr_config, pcgr_data) {
         ACMG_PM4 =
           dplyr::if_else(
             stringr::str_detect(
-              .data$CONSEQUENCE, "stop_lost|inframe_deletion|inframe_insertion") &
+              .data$CONSEQUENCE, "stop_lost|inframe_deletion|inframe_insertion"
+            ) &
               is.na(.data$RMSK_HIT) & .data$cpsr_gene_moi == "AD",
-            TRUE, FALSE, FALSE)) %>%
+            TRUE, FALSE, FALSE
+          )
+      ) %>%
       dplyr::mutate(
         ACMG_PPC1 =
           dplyr::if_else(
             stringr::str_detect(
-              .data$CONSEQUENCE, "stop_lost|inframe_deletion|inframe_insertion") &
+              .data$CONSEQUENCE, "stop_lost|inframe_deletion|inframe_insertion"
+            ) &
               is.na(.data$RMSK_HIT) & (.data$cpsr_gene_moi == "AR" | is.na(.data$cpsr_gene_moi)),
-            TRUE, FALSE, FALSE))
+            TRUE, FALSE, FALSE
+          )
+      )
   }
 
   ## Assign logical ACMG evidence indicator
@@ -1010,7 +1151,9 @@ assign_pathogenicity_evidence <- function(cpg_calls, cpsr_config, pcgr_data) {
           (is.na(.data$BENIGN_MISSENSE_RATE) | .data$BENIGN_MISSENSE_RATE <= 0.1) &
             (is.na(.data$PATH_TRUNCATION_RATE) | .data$PATH_TRUNCATION_RATE < 0.5) &
             stringr::str_detect(.data$CONSEQUENCE, "^missense_variant"),
-          TRUE, FALSE, FALSE))
+          TRUE, FALSE, FALSE
+        )
+    )
 
   ## Assign a logical ACMG evidence indicator
   # ACMG_BP1 - Missense variant in a gene for which primarily truncating
@@ -1019,8 +1162,10 @@ assign_pathogenicity_evidence <- function(cpg_calls, cpsr_config, pcgr_data) {
     dplyr::mutate(
       ACMG_BP1 =
         dplyr::if_else(.data$PATH_TRUNCATION_RATE > 0.90 &
-                         stringr::str_detect(.data$CONSEQUENCE, "^missense_variant"),
-                       TRUE, FALSE, FALSE))
+          stringr::str_detect(.data$CONSEQUENCE, "^missense_variant"),
+        TRUE, FALSE, FALSE
+        )
+    )
 
   ## Assign a logical ACMG evidence indicator
   # ACMG_BP7 - Silent/intronic variant outside of the splice site consensus
@@ -1032,10 +1177,13 @@ assign_pathogenicity_evidence <- function(cpg_calls, cpsr_config, pcgr_data) {
             (as.integer(.data$INTRON_POSITION) > 0 & as.integer(.data$INTRON_POSITION) > 6) |
             (as.integer(.data$EXON_POSITION) < 0 & as.integer(.data$EXON_POSITION) < -2) |
             (as.integer(.data$EXON_POSITION) > 0 & as.integer(.data$EXON_POSITION) > 1)) &
-            stringr::str_detect(
-              .data$CONSEQUENCE,
-              "^(synonymous_variant|intron_variant|splice_region_variant)"),
-          TRUE, FALSE, FALSE))
+          stringr::str_detect(
+            .data$CONSEQUENCE,
+            "^(synonymous_variant|intron_variant|splice_region_variant)"
+          ),
+        TRUE, FALSE, FALSE
+        )
+    )
 
   ## Assign a logical ACMG evidence indicator
   # ACMG_BP3 - Variants in promoter or untranslated regions
@@ -1045,8 +1193,11 @@ assign_pathogenicity_evidence <- function(cpg_calls, cpsr_config, pcgr_data) {
         dplyr::if_else(
           stringr::str_detect(
             .data$CONSEQUENCE,
-            "^(downstream|upstream|5_prime_UTR_variant|3_prime_UTR_variant)"),
-          TRUE, FALSE, FALSE))
+            "^(downstream|upstream|5_prime_UTR_variant|3_prime_UTR_variant)"
+          ),
+          TRUE, FALSE, FALSE
+        )
+    )
 
 
   ## Assign logical ACMG evidence indicators
@@ -1058,7 +1209,7 @@ assign_pathogenicity_evidence <- function(cpg_calls, cpsr_config, pcgr_data) {
 
   cpg_calls$codon_prefix <- NA
   if (nrow(cpg_calls[!is.na(cpg_calls$CONSEQUENCE) &
-                     cpg_calls$CONSEQUENCE == "missense_variant", ]) > 0) {
+    cpg_calls$CONSEQUENCE == "missense_variant", ]) > 0) {
     cpg_calls[cpg_calls$CONSEQUENCE == "missense_variant", ]$codon_prefix <-
       stringr::str_match(cpg_calls[cpg_calls$CONSEQUENCE == "missense_variant", ]$HGVSp_short, "p\\.[A-Z]{1}[0-9]{1,}")
   }
@@ -1066,33 +1217,46 @@ assign_pathogenicity_evidence <- function(cpg_calls, cpsr_config, pcgr_data) {
   if (nrow(cpg_calls[!is.na(cpg_calls$codon_prefix), ]) > 0) {
     cpg_calls_pathogenic_codon <-
       dplyr::left_join(
-        dplyr::filter(dplyr::select(cpg_calls, .data$VAR_ID, .data$codon_prefix, .data$SYMBOL),
-                      !is.na(.data$codon_prefix)),
+        dplyr::filter(
+          dplyr::select(cpg_calls, .data$VAR_ID, .data$codon_prefix, .data$SYMBOL),
+          !is.na(.data$codon_prefix)
+        ),
         pcgr_data[["clinvar"]][["cpg_loci"]][["hi"]][["P"]][["codon"]],
-        by = c("codon_prefix" = "codon_prefix", "SYMBOL" = "symbol")) %>%
+        by = c("codon_prefix" = "codon_prefix", "SYMBOL" = "symbol")
+      ) %>%
       dplyr::filter(.data$clinvar_pathogenic_codon == T)
     cpg_calls <- cpg_calls %>%
-      dplyr::left_join(dplyr::select(cpg_calls_pathogenic_codon,
-                                     .data$VAR_ID, .data$clinvar_pathogenic_codon),
-                       by = c("VAR_ID"))
+      dplyr::left_join(
+        dplyr::select(
+          cpg_calls_pathogenic_codon,
+          .data$VAR_ID, .data$clinvar_pathogenic_codon
+        ),
+        by = c("VAR_ID")
+      )
 
     cpg_calls_benign_codon <-
       dplyr::left_join(
-        dplyr::filter(dplyr::select(cpg_calls, .data$VAR_ID, .data$codon_prefix, .data$SYMBOL),
-                      !is.na(.data$codon_prefix)),
+        dplyr::filter(
+          dplyr::select(cpg_calls, .data$VAR_ID, .data$codon_prefix, .data$SYMBOL),
+          !is.na(.data$codon_prefix)
+        ),
         pcgr_data[["clinvar"]][["cpg_loci"]][["hi"]][["B"]][["codon"]],
-        by = c("codon_prefix" = "codon_prefix", "SYMBOL" = "symbol")) %>%
+        by = c("codon_prefix" = "codon_prefix", "SYMBOL" = "symbol")
+      ) %>%
       dplyr::filter(.data$clinvar_benign_codon == T)
 
     cpg_calls <- cpg_calls %>%
       dplyr::left_join(
         dplyr::select(cpg_calls_benign_codon, .data$VAR_ID, .data$clinvar_benign_codon),
-        by = c("VAR_ID")) %>%
+        by = c("VAR_ID")
+      ) %>%
       dplyr::mutate(ACMG_PM5 = dplyr::if_else(
-        .data$clinvar_pathogenic_codon == TRUE, TRUE, FALSE, FALSE)) %>%
+        .data$clinvar_pathogenic_codon == TRUE, TRUE, FALSE, FALSE
+      )) %>%
       dplyr::mutate(ACMG_BMC1 = dplyr::if_else(
-        .data$clinvar_benign_codon == TRUE, TRUE, FALSE, FALSE))
-  }else{
+        .data$clinvar_benign_codon == TRUE, TRUE, FALSE, FALSE
+      ))
+  } else {
     cpg_calls$ACMG_PM5 <- FALSE
     cpg_calls$ACMG_BMC1 <- FALSE
     cpg_calls$clinvar_pathogenic_codon <- NA
@@ -1105,36 +1269,51 @@ assign_pathogenicity_evidence <- function(cpg_calls, cpsr_config, pcgr_data) {
       dplyr::left_join(
         dplyr::filter(
           dplyr::select(cpg_calls, .data$VAR_ID, .data$HGVSp_short, .data$SYMBOL),
-          !is.na(.data$HGVSp_short)),
+          !is.na(.data$HGVSp_short)
+        ),
         pcgr_data[["clinvar"]][["cpg_loci"]][["hi"]][["P"]][["peptide_change"]],
-        by = c("HGVSp_short" = "hgvs_p", "SYMBOL" = "symbol")) %>%
+        by = c("HGVSp_short" = "hgvs_p", "SYMBOL" = "symbol")
+      ) %>%
       dplyr::filter(.data$clinvar_pathogenic == T)
 
     cpg_calls <- cpg_calls %>%
       dplyr::left_join(
-        dplyr::select(cpg_calls_pathogenic_hgvsp,
-                      .data$VAR_ID, .data$clinvar_pathogenic), by = c("VAR_ID"))
+        dplyr::select(
+          cpg_calls_pathogenic_hgvsp,
+          .data$VAR_ID, .data$clinvar_pathogenic
+        ),
+        by = c("VAR_ID")
+      )
 
     cpg_calls_benign_hgvsp <-
       dplyr::left_join(
         dplyr::filter(
           dplyr::select(cpg_calls, .data$VAR_ID, .data$HGVSp_short, .data$SYMBOL),
-          !is.na(.data$HGVSp_short)),
+          !is.na(.data$HGVSp_short)
+        ),
         pcgr_data[["clinvar"]][["cpg_loci"]][["hi"]][["B"]][["peptide_change"]],
-        by = c("HGVSp_short" = "hgvs_p", "SYMBOL" = "symbol")) %>%
+        by = c("HGVSp_short" = "hgvs_p", "SYMBOL" = "symbol")
+      ) %>%
       dplyr::filter(.data$clinvar_benign == T)
 
     cpg_calls <- cpg_calls %>%
       dplyr::left_join(
         dplyr::select(cpg_calls_benign_hgvsp, .data$VAR_ID, .data$clinvar_benign),
-                       by = c("VAR_ID")) %>%
-      dplyr::mutate(ACMG_PS1 =
-                      dplyr::if_else(.data$clinvar_pathogenic == TRUE,
-                                     TRUE, FALSE, FALSE)) %>%
-      dplyr::mutate(ACMG_BSC1 =
-                      dplyr::if_else(.data$clinvar_benign == TRUE,
-                                     TRUE, FALSE, FALSE))
-  }else{
+        by = c("VAR_ID")
+      ) %>%
+      dplyr::mutate(
+        ACMG_PS1 =
+          dplyr::if_else(.data$clinvar_pathogenic == TRUE,
+            TRUE, FALSE, FALSE
+          )
+      ) %>%
+      dplyr::mutate(
+        ACMG_BSC1 =
+          dplyr::if_else(.data$clinvar_benign == TRUE,
+            TRUE, FALSE, FALSE
+          )
+      )
+  } else {
     cpg_calls$ACMG_PS1 <- FALSE
     cpg_calls$ACMG_BSC1 <- FALSE
     cpg_calls$clinvar_pathogenic <- NA
@@ -1146,40 +1325,54 @@ assign_pathogenicity_evidence <- function(cpg_calls, cpsr_config, pcgr_data) {
   cpg_calls <- cpg_calls %>%
     dplyr::mutate(
       ACMG_PM5 =
-        dplyr::case_when(.data$ACMG_PM5 == T & .data$ACMG_PS1 == T ~ FALSE,
-                         TRUE ~ as.logical(.data$ACMG_PM5))) %>%
+        dplyr::case_when(
+          .data$ACMG_PM5 == T & .data$ACMG_PS1 == T ~ FALSE,
+          TRUE ~ as.logical(.data$ACMG_PM5)
+        )
+    ) %>%
     ## if previously found coinciding with benign variant (ACMG_BSC1),
     ##  set ACMG_BMC1 to false
     dplyr::mutate(
       ACMG_BMC1 =
-        dplyr::case_when(.data$ACMG_BMC1 == T & .data$ACMG_BSC1 == T ~ FALSE,
-                         TRUE ~ as.logical(.data$ACMG_BMC1))) %>%
+        dplyr::case_when(
+          .data$ACMG_BMC1 == T & .data$ACMG_BSC1 == T ~ FALSE,
+          TRUE ~ as.logical(.data$ACMG_BMC1)
+        )
+    ) %>%
     dplyr::select(
-      -c(.data$clinvar_pathogenic_codon, .data$clinvar_benign_codon,
-         .data$clinvar_pathogenic,
-         .data$clinvar_benign, .data$cpsr_gene_moi, .data$gad_af))
+      -c(
+        .data$clinvar_pathogenic_codon, .data$clinvar_benign_codon,
+        .data$clinvar_pathogenic,
+        .data$clinvar_benign, .data$cpsr_gene_moi, .data$gad_af
+      )
+    )
 
-  ##Assign logical ACMG level
+  ## Assign logical ACMG level
   # PM1 - missense variant in a somatic mutation hotspot as
   # determined by cancerhotspots.org (v2)
   cpg_calls <- cpg_calls %>%
     tidyr::separate(
       .data$MUTATION_HOTSPOT,
       c("hotspot_symbol", "hotspot_codon", "hotspot_pvalue"),
-      sep = "\\|", remove = F, extra = "drop") %>%
+      sep = "\\|", remove = F, extra = "drop"
+    ) %>%
     dplyr::mutate(
       hotspot_codon =
         dplyr::if_else(!is.na(.data$hotspot_codon),
-                       paste0("p.", .data$hotspot_codon),
-                       as.character(NA))) %>%
+          paste0("p.", .data$hotspot_codon),
+          as.character(NA)
+        )
+    ) %>%
     dplyr::mutate(
       ACMG_PM1 =
         dplyr::if_else(!is.na(.data$hotspot_codon) &
-                         !is.na(.data$hotspot_symbol) &
-                         !is.na(.data$codon_prefix) &
-                         .data$SYMBOL == .data$hotspot_symbol &
-                         .data$hotspot_codon == .data$codon_prefix,
-                       TRUE, FALSE))
+          !is.na(.data$hotspot_symbol) &
+          !is.na(.data$codon_prefix) &
+          .data$SYMBOL == .data$hotspot_symbol &
+          .data$hotspot_codon == .data$codon_prefix,
+        TRUE, FALSE
+        )
+    )
 
   return(cpg_calls)
 }
@@ -1195,12 +1388,13 @@ assign_pathogenicity_evidence <- function(cpg_calls, cpsr_config, pcgr_data) {
 #'
 #' @export
 determine_pathogenicity_classification <- function(cpg_calls) {
-
   evidence_codes <- pcgrr::cpsr_acmg[["evidence_codes"]]
 
-  path_cols <- c("CPSR_CLASSIFICATION", "CPSR_CLASSIFICATION_DOC",
-                 "CPSR_CLASSIFICATION_CODE",
-                "cpsr_score_pathogenic", "cpsr_score_benign")
+  path_cols <- c(
+    "CPSR_CLASSIFICATION", "CPSR_CLASSIFICATION_DOC",
+    "CPSR_CLASSIFICATION_CODE",
+    "cpsr_score_pathogenic", "cpsr_score_benign"
+  )
   cpg_calls <- cpg_calls[, !(colnames(cpg_calls) %in% path_cols)]
 
   cpg_calls$CPSR_CLASSIFICATION <- "VUS"
@@ -1221,22 +1415,33 @@ determine_pathogenicity_classification <- function(cpg_calls) {
         dplyr::mutate(
           cpsr_score_benign = .data$cpsr_score_benign +
             dplyr::if_else(pole == "B" & !!rlang::sym(cpsr_evidence_code) == T,
-                           score, 0)) %>%
+              score, 0
+            )
+        ) %>%
         dplyr::mutate(
           cpsr_score_pathogenic = .data$cpsr_score_pathogenic +
             dplyr::if_else(pole == "P" & !!rlang::sym(cpsr_evidence_code) == T,
-                           score, 0)) %>%
+              score, 0
+            )
+        ) %>%
         dplyr::mutate(
           CPSR_CLASSIFICATION_DOC =
             paste0(.data$CPSR_CLASSIFICATION_DOC,
-                   dplyr::if_else(!!rlang::sym(cpsr_evidence_code) == T,
-                                  paste0("- ", description), ""),
-                   sep = "<br>")) %>%
+              dplyr::if_else(!!rlang::sym(cpsr_evidence_code) == T,
+                paste0("- ", description), ""
+              ),
+              sep = "<br>"
+            )
+        ) %>%
         dplyr::mutate(
           CPSR_CLASSIFICATION_CODE =
             paste0(.data$CPSR_CLASSIFICATION_CODE,
-                   dplyr::if_else(!!rlang::sym(cpsr_evidence_code) == T,
-                                  cpsr_evidence_code, ""), sep = "|"))
+              dplyr::if_else(!!rlang::sym(cpsr_evidence_code) == T,
+                cpsr_evidence_code, ""
+              ),
+              sep = "|"
+            )
+        )
     }
     i <- i + 1
   }
@@ -1257,16 +1462,20 @@ determine_pathogenicity_classification <- function(cpg_calls) {
         stringr::str_replace_all(
           stringr::str_replace_all(
             .data$CPSR_CLASSIFICATION_CODE,
-            "(\\|{2,})", "|"),
-          "(^\\|)|(\\|$)", "")
-      ) %>%
+            "(\\|{2,})", "|"
+          ),
+          "(^\\|)|(\\|$)", ""
+        )
+    ) %>%
     dplyr::mutate(
       CPSR_CLASSIFICATION_DOC =
         stringr::str_replace_all(
           stringr::str_replace_all(
             .data$CPSR_CLASSIFICATION_DOC,
-            "(<br>){2,}", "<br>"), "(^(<br>))|((<br>)$)", "")) %>%
-
+            "(<br>){2,}", "<br>"
+          ), "(^(<br>))|((<br>)$)", ""
+        )
+    ) %>%
     ## Adjust scores in cases where critera are acting as a
     ## prerequisite for other criteria
     dplyr::mutate(
@@ -1274,34 +1483,41 @@ determine_pathogenicity_classification <- function(cpg_calls) {
         dplyr::if_else(
           stringr::str_detect(.data$CPSR_CLASSIFICATION_CODE, "ACMG_PVS") &
             stringr::str_detect(.data$CPSR_CLASSIFICATION_CODE, "ACMG_PM2_2"),
-          .data$cpsr_score_pathogenic - 1, .data$cpsr_score_pathogenic)) %>%
+          .data$cpsr_score_pathogenic - 1, .data$cpsr_score_pathogenic
+        )
+    ) %>%
     dplyr::mutate(
       cpsr_score_pathogenic =
         dplyr::if_else(
           stringr::str_detect(.data$CPSR_CLASSIFICATION_CODE, "ACMG_PVS") &
             stringr::str_detect(.data$CPSR_CLASSIFICATION_CODE, "ACMG_PM2_1"),
-          .data$cpsr_score_pathogenic - 0.5, .data$cpsr_score_pathogenic)) %>%
+          .data$cpsr_score_pathogenic - 0.5, .data$cpsr_score_pathogenic
+        )
+    ) %>%
     dplyr::mutate(
       cpsr_score_pathogenic =
         dplyr::if_else(
           stringr::str_detect(.data$CPSR_CLASSIFICATION_CODE, "ACMG_PVS1_10") &
             stringr::str_detect(.data$CPSR_CLASSIFICATION_CODE, "ACMG_PP3"),
-          .data$cpsr_score_pathogenic - 0.5, .data$cpsr_score_pathogenic)) %>%
-
+          .data$cpsr_score_pathogenic - 0.5, .data$cpsr_score_pathogenic
+        )
+    ) %>%
     ## Add scores accumulated with benign criteria and pathogenic criteria
     dplyr::mutate(
       CPSR_PATHOGENICITY_SCORE =
         dplyr::if_else(.data$cpsr_score_benign == 0,
-                       .data$cpsr_score_pathogenic,
-                       .data$cpsr_score_benign)) %>%
+          .data$cpsr_score_pathogenic,
+          .data$cpsr_score_benign
+        )
+    ) %>%
     dplyr::mutate(
       CPSR_PATHOGENICITY_SCORE =
         dplyr::if_else(.data$cpsr_score_benign < 0 &
-                         .data$cpsr_score_pathogenic > 0,
-                       .data$cpsr_score_benign + .data$cpsr_score_pathogenic,
-                       .data$CPSR_PATHOGENICITY_SCORE)) %>%
-
-
+          .data$cpsr_score_pathogenic > 0,
+        .data$cpsr_score_benign + .data$cpsr_score_pathogenic,
+        .data$CPSR_PATHOGENICITY_SCORE
+        )
+    ) %>%
     dplyr::mutate(
       CPSR_CLASSIFICATION =
         dplyr::case_when(
@@ -1313,7 +1529,9 @@ determine_pathogenicity_classification <- function(cpg_calls) {
           .data$CPSR_PATHOGENICITY_SCORE >= p_lower_limit ~ "Pathogenic",
           .data$CPSR_PATHOGENICITY_SCORE >= lp_lower_limit &
             .data$CPSR_PATHOGENICITY_SCORE <= lp_upper_limit ~ "Likely_Pathogenic",
-          TRUE ~ as.character("VUS"))) %>%
+          TRUE ~ as.character("VUS")
+        )
+    ) %>%
     dplyr::select(-c(.data$cpsr_score_benign, .data$cpsr_score_pathogenic))
 
   # dplyr::mutate(
@@ -1331,7 +1549,6 @@ determine_pathogenicity_classification <- function(cpg_calls) {
   #   dplyr::select(-c(cpsr_score_benign, cpsr_score_pathogenic))
 
   return(cpg_calls)
-
 }
 
 #' Function that assign variants to different tiers for
@@ -1347,311 +1564,366 @@ assign_variant_tiers <-
            config = NULL,
            cpsr_display_cols = NULL,
            cpsr_tsv_cols = NULL) {
+    # dot_args <- list(...)
 
-
-  #dot_args <- list(...)
-
-  evidence_codes <- pcgrr::cpsr_acmg[['evidence_codes']] %>%
-    dplyr::filter(.data$cpsr_evidence_code != "ACMG_BS2_1" &
-                    .data$cpsr_evidence_code != "ACMG_BS2_2" &
-                    .data$cpsr_evidence_code != "ACMG_BS2_3")
-  cpsr_tsv_cols <-
-    c(cpsr_tsv_cols,
-      evidence_codes$cpsr_evidence_code,
-      c("FINAL_CLASSIFICATION",
-        "CPSR_CLASSIFICATION",
-        "CPSR_PATHOGENICITY_SCORE",
-        "CPSR_CLASSIFICATION_CODE",
-        "CPSR_CLASSIFICATION_DOC",
-        "CPSR_CLASSIFICATION_SOURCE"))
-
-  ## Add custom annotation tags to lists of tags to display
-  if (!is.null(config[["preserved_info_tags"]])) {
-    if (config[["preserved_info_tags"]] != "None") {
-      tags <- stringr::str_split(config[["preserved_info_tags"]],
-                                 pattern = ",")[[1]]
-      for (t in tags) {
-        if(nchar(t) == 0){
-          next
-        }
-        t <- stringr::str_trim(t)
-        if (t %in% colnames(cpg_calls)) {
-          cpsr_tsv_cols <- c(cpsr_tsv_cols, t)
-        }else{
-            pcgrr::log4r_warn(
-            paste0("Could NOT detect the following tag in query VCF: ", tag))
-        }
-      }
-    }
-  }
-
-
-  pcgrr::log4r_info(paste0("Generating tiered set of result variants for ",
-                    "output in tab-separated values (TSV) file"))
-
-  snv_indel_report <- pcgrr::init_report(config = config,
-                                         type = "germline",
-                                         class = "snv_indel")
-
-  #predispose_tags <- cpsr_tsv_cols
-
-  snv_indel_report[["variant_set"]][["class5"]] <- cpg_calls %>%
-    dplyr::filter(!is.na(.data$CLINVAR_CLASSIFICATION) &
-                    .data$CLINVAR_CLASSIFICATION == "Pathogenic") %>%
-    dplyr::mutate(CPSR_CLASSIFICATION_SOURCE = "ClinVar")
-
-  snv_indel_report[["variant_set"]][["class4"]] <- cpg_calls %>%
-    dplyr::filter(!is.na(.data$CLINVAR_CLASSIFICATION) &
-                    .data$CLINVAR_CLASSIFICATION == "Likely_Pathogenic") %>%
-    dplyr::mutate(CPSR_CLASSIFICATION_SOURCE = "ClinVar")
-
-  snv_indel_report[["variant_set"]][["class3"]] <- cpg_calls %>%
-    dplyr::filter(!is.na(.data$CLINVAR_CLASSIFICATION) &
-                    .data$CLINVAR_CLASSIFICATION == "VUS") %>%
-    dplyr::mutate(CPSR_CLASSIFICATION_SOURCE = "ClinVar")
-
-  snv_indel_report[["variant_set"]][["class2"]] <- cpg_calls %>%
-    dplyr::filter(!is.na(.data$CLINVAR_CLASSIFICATION) &
-                    .data$CLINVAR_CLASSIFICATION == "Likely_Benign") %>%
-    dplyr::mutate(CPSR_CLASSIFICATION_SOURCE = "ClinVar")
-
-  snv_indel_report[["variant_set"]][["class1"]] <- cpg_calls %>%
-    dplyr::filter(!is.na(.data$CLINVAR_CLASSIFICATION) &
-                    .data$CLINVAR_CLASSIFICATION == "Benign") %>%
-    dplyr::mutate(CPSR_CLASSIFICATION_SOURCE = "ClinVar")
-
-  ## identify remaining calls not registered in ClinVar
-  all_clinvar_calls <- data.frame()
-  for (c in c("class1", "class2", "class3", "class4", "class5")) {
-    all_clinvar_calls <- all_clinvar_calls %>%
-      dplyr::bind_rows(
-        dplyr::select(
-          snv_indel_report[["variant_set"]][[c]],
-          .data$VAR_ID)
-        )
-  }
-  cpg_calls_non_clinvar <- cpg_calls %>%
-    dplyr::anti_join(all_clinvar_calls, by = c("VAR_ID"))
-
-  n_nonclinvar <- nrow(cpg_calls_non_clinvar)
-
-  cpg_calls_non_clinvar <- cpg_calls_non_clinvar %>%
-    dplyr::filter(is.na(.data$GLOBAL_AF_GNOMAD) |
-                    .data$GLOBAL_AF_GNOMAD <= config[["popgen"]][["maf_upper_threshold"]])
-  n_maf_filtered <- n_nonclinvar - nrow(cpg_calls_non_clinvar)
-  pcgrr::log4r_info(
-    paste0("Ignoring n = ", n_maf_filtered,
-           " unclassified variants with a global MAF frequency above ",
-           config[["popgen"]][["maf_upper_threshold"]]))
-
-  n_after_maf_filtering <- nrow(cpg_calls_non_clinvar)
-
-  non_clinvar_calls <- list()
-  non_clinvar_calls[["class5"]] <- cpg_calls_non_clinvar %>%
-    dplyr::filter(.data$CPSR_CLASSIFICATION == "Pathogenic") %>%
-    dplyr::mutate(CPSR_CLASSIFICATION_SOURCE = "Other")
-
-  non_clinvar_calls[["class4"]] <- cpg_calls_non_clinvar %>%
-    dplyr::filter(.data$CPSR_CLASSIFICATION == "Likely_Pathogenic") %>%
-    dplyr::mutate(CPSR_CLASSIFICATION_SOURCE = "Other")
-
-  non_clinvar_calls[["class3"]] <- cpg_calls_non_clinvar %>%
-    dplyr::filter(.data$CPSR_CLASSIFICATION == "VUS") %>%
-    dplyr::mutate(CPSR_CLASSIFICATION_SOURCE = "Other")
-
-  non_clinvar_calls[["class2"]] <- cpg_calls_non_clinvar %>%
-    dplyr::filter(.data$CPSR_CLASSIFICATION == "Likely_Benign") %>%
-    dplyr::mutate(CPSR_CLASSIFICATION_SOURCE = "Other")
-
-  non_clinvar_calls[["class1"]] <- cpg_calls_non_clinvar %>%
-    dplyr::filter(.data$CPSR_CLASSIFICATION == "Benign") %>%
-    dplyr::mutate(CPSR_CLASSIFICATION_SOURCE = "Other")
-
-  for (c in c("class1", "class2", "class3", "class4", "class5")) {
-
-      pcgrr::log4r_info(paste0("Merging ClinVar-classified variants and CPSR-classified (novel) variants - ",c))
-    snv_indel_report[["variant_set"]][[c]] <-
-      dplyr::bind_rows(non_clinvar_calls[[c]],
-                       snv_indel_report[["variant_set"]][[c]])
-
-
-    if(nrow(snv_indel_report[["variant_set"]][[c]]) == 0){
-        pcgrr::log4r_info(paste0("Zero variants found - ", c))
-    }
-
-    ## set FINAL_CLASSIFICATION col
-    snv_indel_report[["variant_set"]][[c]] <-
-      snv_indel_report[["variant_set"]][[c]] %>%
-      dplyr::mutate(
-        FINAL_CLASSIFICATION = dplyr::case_when(
-          !is.na(.data$CLINVAR_CLASSIFICATION) ~ as.character(.data$CLINVAR_CLASSIFICATION),
-          is.na(.data$CLINVAR_CLASSIFICATION) ~ as.character(.data$CPSR_CLASSIFICATION),
-          TRUE ~ as.character(NA)
+    evidence_codes <- pcgrr::cpsr_acmg[["evidence_codes"]] %>%
+      dplyr::filter(.data$cpsr_evidence_code != "ACMG_BS2_1" &
+        .data$cpsr_evidence_code != "ACMG_BS2_2" &
+        .data$cpsr_evidence_code != "ACMG_BS2_3")
+    cpsr_tsv_cols <-
+      c(
+        cpsr_tsv_cols,
+        evidence_codes$cpsr_evidence_code,
+        c(
+          "FINAL_CLASSIFICATION",
+          "CPSR_CLASSIFICATION",
+          "CPSR_PATHOGENICITY_SCORE",
+          "CPSR_CLASSIFICATION_CODE",
+          "CPSR_CLASSIFICATION_DOC",
+          "CPSR_CLASSIFICATION_SOURCE"
         )
       )
 
-
-    ## If not 'classify_all' is turned on,
-    ## remove CPSR classifications for existing ClinVar classifications
-    if (config[["classify_all"]] == F) {
-      snv_indel_report[["variant_set"]][[c]] <-
-        snv_indel_report[["variant_set"]][[c]] %>%
-        dplyr::mutate(
-          CPSR_CLASSIFICATION =
-            dplyr::if_else(!is.na(.data$CLINVAR_CLASSIFICATION),
-                           "", as.character(.data$CPSR_CLASSIFICATION))) %>%
-        dplyr::mutate(
-          CPSR_CLASSIFICATION_DOC =
-            dplyr::if_else(!is.na(.data$CLINVAR_CLASSIFICATION),
-                           "", as.character(.data$CPSR_CLASSIFICATION_DOC))) %>%
-        dplyr::mutate(
-          CPSR_CLASSIFICATION_CODE =
-            dplyr::if_else(!is.na(.data$CLINVAR_CLASSIFICATION),
-                           "", as.character(.data$CPSR_CLASSIFICATION_CODE))) %>%
-        dplyr::mutate(
-          CPSR_PATHOGENICITY_SCORE =
-            dplyr::if_else(!is.na(.data$CLINVAR_CLASSIFICATION),
-                           as.numeric(NA),
-                           as.numeric(.data$CPSR_PATHOGENICITY_SCORE)))
-    }
-    snv_indel_report[["variant_set"]][[c]] <-
-      snv_indel_report[["variant_set"]][[c]] %>%
-      dplyr::arrange(.data$CPSR_CLASSIFICATION_SOURCE,
-                     dplyr::desc(.data$CANCER_PHENOTYPE),
-                     dplyr::desc(.data$CPSR_PATHOGENICITY_SCORE))
-      #dplyr::select(-CANCER_PHENOTYPE)
-
-    if(config[['visual']][['table_display']] == 'full'){
-      cols_in_tsv_not_display_cols <-
-        setdiff(cpsr_tsv_cols, cpsr_display_cols)
-
-      cpsr_display_cols <-
-        c(cpsr_display_cols,
-          cols_in_tsv_not_display_cols)
-
-      cpsr_display_cols <-
-        cpsr_display_cols[!cpsr_display_cols %in% c("AMINO_ACID_START","AMINO_ACID_END","EXON","CIVIC_ID","CIVIC_ID_SEGMENT")]
-    }
-
-    snv_indel_report[["disp"]][[c]] <-
-      dplyr::select(snv_indel_report[["variant_set"]][[c]],
-                    dplyr::one_of(cpsr_display_cols))
-    snv_indel_report[["variant_set"]][[c]] <-
-      dplyr::select(snv_indel_report[["variant_set"]][[c]],
-                    dplyr::one_of(cpsr_tsv_cols))
-
-    snv_indel_report[["variant_set"]][[c]]$DBSNP <-
-      unlist(lapply(
-        stringr::str_match_all(snv_indel_report[["variant_set"]][[c]]$DBSNP,
-                               ">rs[0-9]{1,}<"), paste, collapse = ","))
-    snv_indel_report[["variant_set"]][[c]]$DBSNP <-
-      stringr::str_replace_all(
-        snv_indel_report[["variant_set"]][[c]]$DBSNP, ">|<", "")
-    snv_indel_report[["variant_set"]][[c]]$GENE_NAME <-
-      unlist(lapply(
-        stringr::str_match_all(
-          snv_indel_report[["variant_set"]][[c]]$GENE_NAME, ">.+<"),
-        paste, collapse = ","))
-    snv_indel_report[["variant_set"]][[c]]$GENE_NAME <-
-      stringr::str_replace_all(
-        snv_indel_report[["variant_set"]][[c]]$GENE_NAME, ">|<", "")
-    snv_indel_report[["variant_set"]][[c]]$PROTEIN_DOMAIN <-
-      unlist(lapply(
-        stringr::str_match_all(
-          snv_indel_report[["variant_set"]][[c]]$PROTEIN_DOMAIN, ">.+<"),
-        paste, collapse = ","))
-    snv_indel_report[["variant_set"]][[c]]$PROTEIN_DOMAIN <-
-      stringr::str_replace_all(
-        snv_indel_report[["variant_set"]][[c]]$PROTEIN_DOMAIN, ">|<", "")
-    snv_indel_report[["variant_set"]][[c]]$CPSR_CLASSIFICATION_DOC <-
-      stringr::str_replace_all(
-        snv_indel_report[["variant_set"]][[c]]$CPSR_CLASSIFICATION_DOC,
-        "<br>-", ",")
-    snv_indel_report[["variant_set"]][[c]]$CPSR_CLASSIFICATION_DOC <-
-      stringr::str_replace_all(
-        snv_indel_report[["variant_set"]][[c]]$CPSR_CLASSIFICATION_DOC,
-        "^, ", "")
-
-    snv_indel_report[["variant_set"]][[c]] <-
-      snv_indel_report[["variant_set"]][[c]] %>%
-      dplyr::select(c("GENOMIC_CHANGE",
-                      "VAR_ID",
-                      "GENOTYPE",
-                      "CPSR_CLASSIFICATION_SOURCE",
-                      "GENOME_VERSION",
-                      "VCF_SAMPLE_ID",
-                      "VARIANT_CLASS",
-                      "CODING_STATUS",
-                      "SYMBOL",
-                      "GENE_NAME",
-                      "CCDS",
-                      "ENTREZ_ID",
-                      "UNIPROT_ID",
-                      "ENSEMBL_GENE_ID",
-                      "ENSEMBL_TRANSCRIPT_ID",
-                      "REFSEQ_MRNA",
-                      "ONCOGENE",
-                      "TUMOR_SUPPRESSOR",
-                      "CONSEQUENCE",
-                      "VEP_ALL_CSQ",
-                      "REGULATORY_ANNOTATION",
-                      "PROTEIN_CHANGE",
-                      "PROTEIN_DOMAIN",
-                      "DBSNP",
-                      "HGVSp",
-                      "HGVSc",
-                      "LAST_EXON",
-                      "EXON_POSITION",
-                      "INTRON_POSITION",
-                      "CDS_CHANGE",
-                      "MUTATION_HOTSPOT",
-                      "RMSK_HIT",
-                      "PROTEIN_FEATURE",
-                      "EFFECT_PREDICTIONS",
-                      "LOSS_OF_FUNCTION",
-                      "DBSNP",
-                      "CANCER_PHENOTYPE",
-                      "CLINVAR_CLASSIFICATION",
-                      "CLINVAR_MSID",
-                      "CLINVAR_VARIANT_ORIGIN",
-                      "CLINVAR_CONFLICTED",
-                      "CLINVAR_PHENOTYPE",
-                      "CLINVAR_REVIEW_STATUS_STARS"),
-                    dplyr::everything())
-
-    for (col in colnames(snv_indel_report[["variant_set"]][[c]])) {
-      if (nrow(snv_indel_report[["variant_set"]][[c]][!is.na(
-        snv_indel_report[["variant_set"]][[c]][, col]) &
-        snv_indel_report[["variant_set"]][[c]][, col] == "", ]) > 0) {
-        snv_indel_report[["variant_set"]][[c]][!is.na(
-          snv_indel_report[["variant_set"]][[c]][, col]) &
-            snv_indel_report[["variant_set"]][[c]][, col] == "", col] <- NA
-      }
-    }
-
-    population_tags <- unique(
-      c("GLOBAL_AF_GNOMAD", config[["popgen"]][["vcftag_gnomad"]]))
-    for (tag in population_tags) {
-      if (tag %in% colnames(snv_indel_report[["disp"]][[c]])) {
-        if (nrow(snv_indel_report[["disp"]][[c]][is.na(
-          snv_indel_report[["disp"]][[c]][, tag]), ]) > 0) {
-          snv_indel_report[["disp"]][[c]][is.na(
-            snv_indel_report[["disp"]][[c]][, tag]), tag] <- 0.00
+    ## Add custom annotation tags to lists of tags to display
+    if (!is.null(config[["preserved_info_tags"]])) {
+      if (config[["preserved_info_tags"]] != "None") {
+        tags <- stringr::str_split(config[["preserved_info_tags"]],
+          pattern = ","
+        )[[1]]
+        for (t in tags) {
+          if (nchar(t) == 0) {
+            next
+          }
+          t <- stringr::str_trim(t)
+          if (t %in% colnames(cpg_calls)) {
+            cpsr_tsv_cols <- c(cpsr_tsv_cols, t)
+          } else {
+            pcgrr::log4r_warn(
+              paste0("Could NOT detect the following tag in query VCF: ", tag)
+            )
+          }
         }
       }
     }
+
+
+    pcgrr::log4r_info(paste0(
+      "Generating tiered set of result variants for ",
+      "output in tab-separated values (TSV) file"
+    ))
+
+    snv_indel_report <- pcgrr::init_report(
+      config = config,
+      type = "germline",
+      class = "snv_indel"
+    )
+
+    # predispose_tags <- cpsr_tsv_cols
+
+    snv_indel_report[["variant_set"]][["class5"]] <- cpg_calls %>%
+      dplyr::filter(!is.na(.data$CLINVAR_CLASSIFICATION) &
+        .data$CLINVAR_CLASSIFICATION == "Pathogenic") %>%
+      dplyr::mutate(CPSR_CLASSIFICATION_SOURCE = "ClinVar")
+
+    snv_indel_report[["variant_set"]][["class4"]] <- cpg_calls %>%
+      dplyr::filter(!is.na(.data$CLINVAR_CLASSIFICATION) &
+        .data$CLINVAR_CLASSIFICATION == "Likely_Pathogenic") %>%
+      dplyr::mutate(CPSR_CLASSIFICATION_SOURCE = "ClinVar")
+
+    snv_indel_report[["variant_set"]][["class3"]] <- cpg_calls %>%
+      dplyr::filter(!is.na(.data$CLINVAR_CLASSIFICATION) &
+        .data$CLINVAR_CLASSIFICATION == "VUS") %>%
+      dplyr::mutate(CPSR_CLASSIFICATION_SOURCE = "ClinVar")
+
+    snv_indel_report[["variant_set"]][["class2"]] <- cpg_calls %>%
+      dplyr::filter(!is.na(.data$CLINVAR_CLASSIFICATION) &
+        .data$CLINVAR_CLASSIFICATION == "Likely_Benign") %>%
+      dplyr::mutate(CPSR_CLASSIFICATION_SOURCE = "ClinVar")
+
+    snv_indel_report[["variant_set"]][["class1"]] <- cpg_calls %>%
+      dplyr::filter(!is.na(.data$CLINVAR_CLASSIFICATION) &
+        .data$CLINVAR_CLASSIFICATION == "Benign") %>%
+      dplyr::mutate(CPSR_CLASSIFICATION_SOURCE = "ClinVar")
+
+    ## identify remaining calls not registered in ClinVar
+    all_clinvar_calls <- data.frame()
+    for (c in c("class1", "class2", "class3", "class4", "class5")) {
+      all_clinvar_calls <- all_clinvar_calls %>%
+        dplyr::bind_rows(
+          dplyr::select(
+            snv_indel_report[["variant_set"]][[c]],
+            .data$VAR_ID
+          )
+        )
+    }
+    cpg_calls_non_clinvar <- cpg_calls %>%
+      dplyr::anti_join(all_clinvar_calls, by = c("VAR_ID"))
+
+    n_nonclinvar <- nrow(cpg_calls_non_clinvar)
+
+    cpg_calls_non_clinvar <- cpg_calls_non_clinvar %>%
+      dplyr::filter(is.na(.data$GLOBAL_AF_GNOMAD) |
+        .data$GLOBAL_AF_GNOMAD <= config[["popgen"]][["maf_upper_threshold"]])
+    n_maf_filtered <- n_nonclinvar - nrow(cpg_calls_non_clinvar)
+    pcgrr::log4r_info(
+      paste0(
+        "Ignoring n = ", n_maf_filtered,
+        " unclassified variants with a global MAF frequency above ",
+        config[["popgen"]][["maf_upper_threshold"]]
+      )
+    )
+
+    n_after_maf_filtering <- nrow(cpg_calls_non_clinvar)
+
+    non_clinvar_calls <- list()
+    non_clinvar_calls[["class5"]] <- cpg_calls_non_clinvar %>%
+      dplyr::filter(.data$CPSR_CLASSIFICATION == "Pathogenic") %>%
+      dplyr::mutate(CPSR_CLASSIFICATION_SOURCE = "Other")
+
+    non_clinvar_calls[["class4"]] <- cpg_calls_non_clinvar %>%
+      dplyr::filter(.data$CPSR_CLASSIFICATION == "Likely_Pathogenic") %>%
+      dplyr::mutate(CPSR_CLASSIFICATION_SOURCE = "Other")
+
+    non_clinvar_calls[["class3"]] <- cpg_calls_non_clinvar %>%
+      dplyr::filter(.data$CPSR_CLASSIFICATION == "VUS") %>%
+      dplyr::mutate(CPSR_CLASSIFICATION_SOURCE = "Other")
+
+    non_clinvar_calls[["class2"]] <- cpg_calls_non_clinvar %>%
+      dplyr::filter(.data$CPSR_CLASSIFICATION == "Likely_Benign") %>%
+      dplyr::mutate(CPSR_CLASSIFICATION_SOURCE = "Other")
+
+    non_clinvar_calls[["class1"]] <- cpg_calls_non_clinvar %>%
+      dplyr::filter(.data$CPSR_CLASSIFICATION == "Benign") %>%
+      dplyr::mutate(CPSR_CLASSIFICATION_SOURCE = "Other")
+
+    for (c in c("class1", "class2", "class3", "class4", "class5")) {
+      pcgrr::log4r_info(paste0("Merging ClinVar-classified variants and CPSR-classified (novel) variants - ", c))
+      snv_indel_report[["variant_set"]][[c]] <-
+        dplyr::bind_rows(
+          non_clinvar_calls[[c]],
+          snv_indel_report[["variant_set"]][[c]]
+        )
+
+
+      if (nrow(snv_indel_report[["variant_set"]][[c]]) == 0) {
+        pcgrr::log4r_info(paste0("Zero variants found - ", c))
+      }
+
+      ## set FINAL_CLASSIFICATION col
+      snv_indel_report[["variant_set"]][[c]] <-
+        snv_indel_report[["variant_set"]][[c]] %>%
+        dplyr::mutate(
+          FINAL_CLASSIFICATION = dplyr::case_when(
+            !is.na(.data$CLINVAR_CLASSIFICATION) ~ as.character(.data$CLINVAR_CLASSIFICATION),
+            is.na(.data$CLINVAR_CLASSIFICATION) ~ as.character(.data$CPSR_CLASSIFICATION),
+            TRUE ~ as.character(NA)
+          )
+        )
+
+
+      ## If not 'classify_all' is turned on,
+      ## remove CPSR classifications for existing ClinVar classifications
+      if (config[["classify_all"]] == F) {
+        snv_indel_report[["variant_set"]][[c]] <-
+          snv_indel_report[["variant_set"]][[c]] %>%
+          dplyr::mutate(
+            CPSR_CLASSIFICATION =
+              dplyr::if_else(!is.na(.data$CLINVAR_CLASSIFICATION),
+                "", as.character(.data$CPSR_CLASSIFICATION)
+              )
+          ) %>%
+          dplyr::mutate(
+            CPSR_CLASSIFICATION_DOC =
+              dplyr::if_else(!is.na(.data$CLINVAR_CLASSIFICATION),
+                "", as.character(.data$CPSR_CLASSIFICATION_DOC)
+              )
+          ) %>%
+          dplyr::mutate(
+            CPSR_CLASSIFICATION_CODE =
+              dplyr::if_else(!is.na(.data$CLINVAR_CLASSIFICATION),
+                "", as.character(.data$CPSR_CLASSIFICATION_CODE)
+              )
+          ) %>%
+          dplyr::mutate(
+            CPSR_PATHOGENICITY_SCORE =
+              dplyr::if_else(!is.na(.data$CLINVAR_CLASSIFICATION),
+                as.numeric(NA),
+                as.numeric(.data$CPSR_PATHOGENICITY_SCORE)
+              )
+          )
+      }
+      snv_indel_report[["variant_set"]][[c]] <-
+        snv_indel_report[["variant_set"]][[c]] %>%
+        dplyr::arrange(
+          .data$CPSR_CLASSIFICATION_SOURCE,
+          dplyr::desc(.data$CANCER_PHENOTYPE),
+          dplyr::desc(.data$CPSR_PATHOGENICITY_SCORE)
+        )
+      # dplyr::select(-CANCER_PHENOTYPE)
+
+      if (config[["visual"]][["table_display"]] == "full") {
+        cols_in_tsv_not_display_cols <-
+          setdiff(cpsr_tsv_cols, cpsr_display_cols)
+
+        cpsr_display_cols <-
+          c(
+            cpsr_display_cols,
+            cols_in_tsv_not_display_cols
+          )
+
+        cpsr_display_cols <-
+          cpsr_display_cols[!cpsr_display_cols %in% c("AMINO_ACID_START", "AMINO_ACID_END", "EXON", "CIVIC_ID", "CIVIC_ID_SEGMENT")]
+      }
+
+      snv_indel_report[["disp"]][[c]] <-
+        dplyr::select(
+          snv_indel_report[["variant_set"]][[c]],
+          dplyr::one_of(cpsr_display_cols)
+        )
+      snv_indel_report[["variant_set"]][[c]] <-
+        dplyr::select(
+          snv_indel_report[["variant_set"]][[c]],
+          dplyr::one_of(cpsr_tsv_cols)
+        )
+
+      snv_indel_report[["variant_set"]][[c]]$DBSNP <-
+        unlist(lapply(
+          stringr::str_match_all(
+            snv_indel_report[["variant_set"]][[c]]$DBSNP,
+            ">rs[0-9]{1,}<"
+          ), paste,
+          collapse = ","
+        ))
+      snv_indel_report[["variant_set"]][[c]]$DBSNP <-
+        stringr::str_replace_all(
+          snv_indel_report[["variant_set"]][[c]]$DBSNP, ">|<", ""
+        )
+      snv_indel_report[["variant_set"]][[c]]$GENE_NAME <-
+        unlist(lapply(
+          stringr::str_match_all(
+            snv_indel_report[["variant_set"]][[c]]$GENE_NAME, ">.+<"
+          ),
+          paste,
+          collapse = ","
+        ))
+      snv_indel_report[["variant_set"]][[c]]$GENE_NAME <-
+        stringr::str_replace_all(
+          snv_indel_report[["variant_set"]][[c]]$GENE_NAME, ">|<", ""
+        )
+      snv_indel_report[["variant_set"]][[c]]$PROTEIN_DOMAIN <-
+        unlist(lapply(
+          stringr::str_match_all(
+            snv_indel_report[["variant_set"]][[c]]$PROTEIN_DOMAIN, ">.+<"
+          ),
+          paste,
+          collapse = ","
+        ))
+      snv_indel_report[["variant_set"]][[c]]$PROTEIN_DOMAIN <-
+        stringr::str_replace_all(
+          snv_indel_report[["variant_set"]][[c]]$PROTEIN_DOMAIN, ">|<", ""
+        )
+      snv_indel_report[["variant_set"]][[c]]$CPSR_CLASSIFICATION_DOC <-
+        stringr::str_replace_all(
+          snv_indel_report[["variant_set"]][[c]]$CPSR_CLASSIFICATION_DOC,
+          "<br>-", ","
+        )
+      snv_indel_report[["variant_set"]][[c]]$CPSR_CLASSIFICATION_DOC <-
+        stringr::str_replace_all(
+          snv_indel_report[["variant_set"]][[c]]$CPSR_CLASSIFICATION_DOC,
+          "^, ", ""
+        )
+
+      snv_indel_report[["variant_set"]][[c]] <-
+        snv_indel_report[["variant_set"]][[c]] %>%
+        dplyr::select(
+          c(
+            "GENOMIC_CHANGE",
+            "VAR_ID",
+            "GENOTYPE",
+            "CPSR_CLASSIFICATION_SOURCE",
+            "GENOME_VERSION",
+            "VCF_SAMPLE_ID",
+            "VARIANT_CLASS",
+            "CODING_STATUS",
+            "SYMBOL",
+            "GENE_NAME",
+            "CCDS",
+            "ENTREZ_ID",
+            "UNIPROT_ID",
+            "ENSEMBL_GENE_ID",
+            "ENSEMBL_TRANSCRIPT_ID",
+            "REFSEQ_MRNA",
+            "ONCOGENE",
+            "TUMOR_SUPPRESSOR",
+            "CONSEQUENCE",
+            "VEP_ALL_CSQ",
+            "REGULATORY_ANNOTATION",
+            "PROTEIN_CHANGE",
+            "PROTEIN_DOMAIN",
+            "DBSNP",
+            "HGVSp",
+            "HGVSc",
+            "LAST_EXON",
+            "EXON_POSITION",
+            "INTRON_POSITION",
+            "CDS_CHANGE",
+            "MUTATION_HOTSPOT",
+            "RMSK_HIT",
+            "PROTEIN_FEATURE",
+            "EFFECT_PREDICTIONS",
+            "LOSS_OF_FUNCTION",
+            "DBSNP",
+            "CANCER_PHENOTYPE",
+            "CLINVAR_CLASSIFICATION",
+            "CLINVAR_MSID",
+            "CLINVAR_VARIANT_ORIGIN",
+            "CLINVAR_CONFLICTED",
+            "CLINVAR_PHENOTYPE",
+            "CLINVAR_REVIEW_STATUS_STARS"
+          ),
+          dplyr::everything()
+        )
+
+      for (col in colnames(snv_indel_report[["variant_set"]][[c]])) {
+        if (nrow(snv_indel_report[["variant_set"]][[c]][!is.na(
+          snv_indel_report[["variant_set"]][[c]][, col]
+        ) &
+          snv_indel_report[["variant_set"]][[c]][, col] == "", ]) > 0) {
+          snv_indel_report[["variant_set"]][[c]][!is.na(
+            snv_indel_report[["variant_set"]][[c]][, col]
+          ) &
+            snv_indel_report[["variant_set"]][[c]][, col] == "", col] <- NA
+        }
+      }
+
+      population_tags <- unique(
+        c("GLOBAL_AF_GNOMAD", config[["popgen"]][["vcftag_gnomad"]])
+      )
+      for (tag in population_tags) {
+        if (tag %in% colnames(snv_indel_report[["disp"]][[c]])) {
+          if (nrow(snv_indel_report[["disp"]][[c]][is.na(
+            snv_indel_report[["disp"]][[c]][, tag]
+          ), ]) > 0) {
+            snv_indel_report[["disp"]][[c]][is.na(
+              snv_indel_report[["disp"]][[c]][, tag]
+            ), tag] <- 0.00
+          }
+        }
+      }
+    }
+
+    snv_indel_report[["variant_set"]][["tsv"]] <-
+      dplyr::bind_rows(
+        snv_indel_report[["variant_set"]][["class5"]],
+        snv_indel_report[["variant_set"]][["class4"]],
+        snv_indel_report[["variant_set"]][["class3"]],
+        snv_indel_report[["variant_set"]][["class2"]],
+        snv_indel_report[["variant_set"]][["class1"]]
+      )
+
+
+    return(snv_indel_report)
   }
-
-  snv_indel_report[["variant_set"]][["tsv"]] <-
-    dplyr::bind_rows(snv_indel_report[["variant_set"]][["class5"]],
-                     snv_indel_report[["variant_set"]][["class4"]],
-                     snv_indel_report[["variant_set"]][["class3"]],
-                     snv_indel_report[["variant_set"]][["class2"]],
-                     snv_indel_report[["variant_set"]][["class1"]])
-
-
-  return(snv_indel_report)
-}
 
 #' Function that retrieves variants in genes recommended for secondary
 #' (secondary) findings
@@ -1662,16 +1934,18 @@ assign_variant_tiers <-
 #'
 #' @export
 retrieve_secondary_calls <- function(calls, umls_map) {
-
   assertable::assert_colnames(
-    calls, colnames = c("CANCER_PREDISPOSITION_SOURCE",
-             "CLINVAR_CLASSIFICATION",
-             "CLINVAR_UMLS_CUI",
-             "GENOTYPE",
-             "SYMBOL",
-             "VAR_ID",
-             "LOSS_OF_FUNCTION",
-             "PROTEIN_CHANGE"),
+    calls,
+    colnames = c(
+      "CANCER_PREDISPOSITION_SOURCE",
+      "CLINVAR_CLASSIFICATION",
+      "CLINVAR_UMLS_CUI",
+      "GENOTYPE",
+      "SYMBOL",
+      "VAR_ID",
+      "LOSS_OF_FUNCTION",
+      "PROTEIN_CHANGE"
+    ),
     only_colnames = F, quiet = T
   )
 
@@ -1681,7 +1955,7 @@ retrieve_secondary_calls <- function(calls, umls_map) {
     dplyr::filter(!is.na(.data$GENOTYPE) & !is.na(.data$SYMBOL))
 
 
-  if(nrow(secondary_calls) == 0){
+  if (nrow(secondary_calls) == 0) {
     # pcgrr::log4r_info(paste0(
     #   "Found n = ",
     #   nrow(secondary_calls),
@@ -1692,74 +1966,75 @@ retrieve_secondary_calls <- function(calls, umls_map) {
 
   secondary_calls <- secondary_calls %>%
     dplyr::filter(!is.na(.data$CANCER_PREDISPOSITION_SOURCE) &
-                    .data$CANCER_PREDISPOSITION_SOURCE == "ACMG_SF30" &
-                    !is.na(.data$CLINVAR_CLASSIFICATION)) %>%
+      .data$CANCER_PREDISPOSITION_SOURCE == "ACMG_SF30" &
+      !is.na(.data$CLINVAR_CLASSIFICATION)) %>%
     dplyr::filter(.data$CLINVAR_CLASSIFICATION == "Pathogenic" |
-                    .data$CLINVAR_CLASSIFICATION == "Likely_Pathogenic") %>%
+      .data$CLINVAR_CLASSIFICATION == "Likely_Pathogenic") %>%
     ## only LOF for TTN
     dplyr::filter(.data$SYMBOL != "TTN" |
-                    (.data$SYMBOL == "TTN" &
-                       .data$LOSS_OF_FUNCTION == T)) %>%
-
+      (.data$SYMBOL == "TTN" &
+        .data$LOSS_OF_FUNCTION == T)) %>%
     ## only homozygotes p.Cys282Tyr HFE carriers
     dplyr::filter(.data$SYMBOL != "HFE" |
-                    (.data$SYMBOL == "HFE" &
-                       (!is.na(.data$PROTEIN_CHANGE) &
-                          stringr::str_detect(.data$PROTEIN_CHANGE,"Cys282Tyr")) &
-                       .data$GENOTYPE == "homozygous"))
+      (.data$SYMBOL == "HFE" &
+        (!is.na(.data$PROTEIN_CHANGE) &
+          stringr::str_detect(.data$PROTEIN_CHANGE, "Cys282Tyr")) &
+        .data$GENOTYPE == "homozygous"))
 
 
 
   ## AR genes
   min_two_variants_required <-
-    data.frame(SYMBOL = 'MUTYH', stringsAsFactors = F) %>%
+    data.frame(SYMBOL = "MUTYH", stringsAsFactors = F) %>%
     dplyr::bind_rows(
-      data.frame(SYMBOL = 'CASQ2', stringsAsFactors = F),
-      data.frame(SYMBOL = 'TRDN', stringsAsFactors = F),
-      data.frame(SYMBOL = 'RPE65', stringsAsFactors = F),
-      data.frame(SYMBOL = 'GAA', stringsAsFactors = F),
-      data.frame(SYMBOL = 'BTD', stringsAsFactors = F),
-      data.frame(SYMBOL = 'ATP7B', stringsAsFactors = F)
+      data.frame(SYMBOL = "CASQ2", stringsAsFactors = F),
+      data.frame(SYMBOL = "TRDN", stringsAsFactors = F),
+      data.frame(SYMBOL = "RPE65", stringsAsFactors = F),
+      data.frame(SYMBOL = "GAA", stringsAsFactors = F),
+      data.frame(SYMBOL = "BTD", stringsAsFactors = F),
+      data.frame(SYMBOL = "ATP7B", stringsAsFactors = F)
     )
 
   if (nrow(secondary_calls) > 0) {
-
     ## Skip MUTYH/RPE65/GAA/BTD/ATP7B if they only occur with one variant
     genes_lacking_twohit_evidence <- secondary_calls %>%
       dplyr::group_by(.data$SYMBOL) %>%
       dplyr::summarise(n = dplyr::n(), .groups = "drop") %>%
       dplyr::filter(.data$n == 1)
 
-    if(nrow(genes_lacking_twohit_evidence) > 0){
+    if (nrow(genes_lacking_twohit_evidence) > 0) {
       genes_lacking_twohit_evidence <- genes_lacking_twohit_evidence %>%
         dplyr::inner_join(min_two_variants_required, by = "SYMBOL")
 
-      if(nrow(genes_lacking_twohit_evidence) > 0){
+      if (nrow(genes_lacking_twohit_evidence) > 0) {
         secondary_calls <- secondary_calls %>%
           dplyr::anti_join(genes_lacking_twohit_evidence, by = "SYMBOL")
       }
     }
 
-    if(nrow(secondary_calls) > 0){
+    if (nrow(secondary_calls) > 0) {
       secondary_calls_per_trait <-
         tidyr::separate_rows(secondary_calls, .data$CLINVAR_UMLS_CUI, sep = ",") %>%
         dplyr::select(.data$VAR_ID, .data$CLINVAR_UMLS_CUI) %>%
         dplyr::left_join(umls_map, by = c("CLINVAR_UMLS_CUI" = "cui")) %>%
         dplyr::rename(CLINVAR_PHENOTYPE = .data$cui_name) %>%
         dplyr::group_by(.data$VAR_ID) %>%
-        dplyr::summarise(CLINVAR_PHENOTYPE =
-                           paste(unique(.data$CLINVAR_PHENOTYPE), collapse="; ")) %>%
+        dplyr::summarise(
+          CLINVAR_PHENOTYPE =
+            paste(unique(.data$CLINVAR_PHENOTYPE), collapse = "; ")
+        ) %>%
         dplyr::distinct()
 
       secondary_calls <-
         dplyr::inner_join(
           secondary_calls,
-          dplyr::select(secondary_calls_per_trait,
-                        .data$VAR_ID, .data$CLINVAR_PHENOTYPE),
-          by = c("VAR_ID" = "VAR_ID"))
-
+          dplyr::select(
+            secondary_calls_per_trait,
+            .data$VAR_ID, .data$CLINVAR_PHENOTYPE
+          ),
+          by = c("VAR_ID" = "VAR_ID")
+        )
     }
-
   }
 
   # pcgrr::log4r_info(paste0(
@@ -1769,7 +2044,6 @@ retrieve_secondary_calls <- function(calls, umls_map) {
   #   "secondary findings from clinical sequencing"))
 
   return(secondary_calls)
-
 }
 
 #' Function that retrieves variants in cancer predisposition genes linked
@@ -1782,9 +2056,8 @@ retrieve_secondary_calls <- function(calls, umls_map) {
 #' @export
 detect_cancer_traits_clinvar <- function(cpg_calls, oncotree, umls_map) {
   if (nrow(cpg_calls) > 0 &
-      "CLINVAR_UMLS_CUI" %in% colnames(cpg_calls) &
-      "VAR_ID" %in% colnames(cpg_calls)) {
-
+    "CLINVAR_UMLS_CUI" %in% colnames(cpg_calls) &
+    "VAR_ID" %in% colnames(cpg_calls)) {
     oncotree <- oncotree %>%
       dplyr::select(.data$cui) %>%
       dplyr::mutate(CANCER_PHENOTYPE = 1) %>%
@@ -1797,45 +2070,52 @@ detect_cancer_traits_clinvar <- function(cpg_calls, oncotree, umls_map) {
     if (n_clinvar > 0) {
       cpg_calls_traits <- as.data.frame(
         tidyr::separate_rows(cpg_calls, .data$CLINVAR_UMLS_CUI, sep = ",") %>%
-        dplyr::select(.data$VAR_ID, .data$CLINVAR_UMLS_CUI) %>%
-        dplyr::left_join(umls_map, by = c("CLINVAR_UMLS_CUI" = "cui")) %>%
-        dplyr::distinct() %>%
-        dplyr::filter(!is.na(.data$cui_name)) %>%
-        dplyr::left_join(oncotree, by = c("CLINVAR_UMLS_CUI" = "cui")) %>%
-        dplyr::mutate(
-          CANCER_PHENOTYPE = dplyr::if_else(is.na(.data$CANCER_PHENOTYPE),
-                                            as.integer(0),
-                                            as.integer(.data$CANCER_PHENOTYPE))) %>%
-        dplyr::mutate(
-          CANCER_PHENOTYPE =
-            dplyr::if_else(stringr::str_detect(tolower(.data$cui_name),
-                                               pcgrr::cancer_phenotypes_regex),
-                           as.integer(1),
-                           as.integer(.data$CANCER_PHENOTYPE))) %>%
-        dplyr::group_by(.data$VAR_ID) %>%
-        dplyr::summarise(
-          CLINVAR_PHENOTYPE = paste(unique(.data$cui_name), collapse = "; "),
-          CANCER_PHENOTYPE = max(.data$CANCER_PHENOTYPE),
-          .groups = "drop") %>%
+          dplyr::select(.data$VAR_ID, .data$CLINVAR_UMLS_CUI) %>%
+          dplyr::left_join(umls_map, by = c("CLINVAR_UMLS_CUI" = "cui")) %>%
+          dplyr::distinct() %>%
+          dplyr::filter(!is.na(.data$cui_name)) %>%
+          dplyr::left_join(oncotree, by = c("CLINVAR_UMLS_CUI" = "cui")) %>%
+          dplyr::mutate(
+            CANCER_PHENOTYPE = dplyr::if_else(is.na(.data$CANCER_PHENOTYPE),
+              as.integer(0),
+              as.integer(.data$CANCER_PHENOTYPE)
+            )
+          ) %>%
+          dplyr::mutate(
+            CANCER_PHENOTYPE =
+              dplyr::if_else(stringr::str_detect(
+                tolower(.data$cui_name),
+                pcgrr::cancer_phenotypes_regex
+              ),
+              as.integer(1),
+              as.integer(.data$CANCER_PHENOTYPE)
+              )
+          ) %>%
+          dplyr::group_by(.data$VAR_ID) %>%
+          dplyr::summarise(
+            CLINVAR_PHENOTYPE = paste(unique(.data$cui_name), collapse = "; "),
+            CANCER_PHENOTYPE = max(.data$CANCER_PHENOTYPE),
+            .groups = "drop"
+          ) %>%
           dplyr::mutate(
             CANCER_PHENOTYPE =
               dplyr::if_else(
                 stringr::str_detect(
                   .data$CLINVAR_PHENOTYPE,
-                  "^(not specified; not provided|not specified|not provided)"),
+                  "^(not specified; not provided|not specified|not provided)"
+                ),
                 as.integer(1),
-                as.integer(.data$CANCER_PHENOTYPE)))
-
+                as.integer(.data$CANCER_PHENOTYPE)
+              )
+          )
       )
 
       cpg_calls <- cpg_calls %>%
         dplyr::left_join(cpg_calls_traits, by = "VAR_ID")
-    }else{
+    } else {
       cpg_calls$CLINVAR_PHENOTYPE <- NA
       cpg_calls$CANCER_PHENOTYPE <- NA
     }
-
-
   }
   return(cpg_calls)
 }
@@ -1848,29 +2128,26 @@ detect_cancer_traits_clinvar <- function(cpg_calls, oncotree, umls_map) {
 #'
 #' @export
 summary_donut_chart <- function(variants_tsv, plot_type = "ClinVar") {
-
   title <- "ClinVar variants"
   p <- NULL
 
   if (nrow(variants_tsv) > 0) {
-
     set_clinvar <- variants_tsv %>%
       dplyr::filter(!is.na(.data$CLINVAR_CLASSIFICATION) &
-                      !(.data$CLINVAR_CLASSIFICATION == "NA"))
+        !(.data$CLINVAR_CLASSIFICATION == "NA"))
     set_other <- variants_tsv %>%
       dplyr::filter(nchar(.data$CPSR_CLASSIFICATION) > 0 &
-                      (is.na(.data$CLINVAR_CLASSIFICATION) |
-                         .data$CLINVAR_CLASSIFICATION == "NA"))
+        (is.na(.data$CLINVAR_CLASSIFICATION) |
+          .data$CLINVAR_CLASSIFICATION == "NA"))
 
     if ((plot_type == "ClinVar" & nrow(set_clinvar) > 0) |
-        (plot_type != "ClinVar" & nrow(set_other) > 0)) {
-
+      (plot_type != "ClinVar" & nrow(set_other) > 0)) {
       m <- data.frame()
 
       if (plot_type == "ClinVar") {
         if (nrow(set_clinvar) > 0) {
           t <- paste0("n = ", nrow(set_clinvar))
-          title <- bquote("ClinVar variants, "~bold(.(t)))
+          title <- bquote("ClinVar variants, " ~ bold(.(t)))
           m <- as.data.frame(set_clinvar %>%
             dplyr::group_by(.data$CLINVAR_CLASSIFICATION) %>%
             dplyr::summarise(n = dplyr::n()) %>%
@@ -1878,17 +2155,20 @@ summary_donut_chart <- function(variants_tsv, plot_type = "ClinVar") {
             dplyr::mutate(
               level =
                 factor(
-                  .data$level, levels =
-                    pcgrr::color_palette[["pathogenicity"]][["levels"]])) %>%
+                  .data$level,
+                  levels =
+                    pcgrr::color_palette[["pathogenicity"]][["levels"]]
+                )
+            ) %>%
             dplyr::arrange(.data$level) %>%
             dplyr::mutate(prop = as.numeric(.data$n / sum(.data$n))) %>%
             dplyr::mutate(lab.ypos = cumsum(.data$prop) - 0.5 * .data$prop) %>%
             dplyr::mutate(n = as.character(.data$n))
         }
-      }else{
+      } else {
         if (nrow(set_other) > 0) {
           t <- paste0("n = ", nrow(set_other))
-          title <- bquote("Other variants, CPSR-classified, "~bold(.(t)))
+          title <- bquote("Other variants, CPSR-classified, " ~ bold(.(t)))
           m <- as.data.frame(set_other %>%
             dplyr::group_by(.data$CPSR_CLASSIFICATION) %>%
             dplyr::summarise(n = dplyr::n()) %>%
@@ -1896,12 +2176,13 @@ summary_donut_chart <- function(variants_tsv, plot_type = "ClinVar") {
             dplyr::mutate(
               level = factor(
                 .data$level,
-                levels = pcgrr::color_palette[["pathogenicity"]][["levels"]])) %>%
+                levels = pcgrr::color_palette[["pathogenicity"]][["levels"]]
+              )
+            ) %>%
             dplyr::arrange(.data$level) %>%
             dplyr::mutate(prop = as.numeric(.data$n / sum(.data$n))) %>%
             dplyr::mutate(lab.ypos = cumsum(.data$prop) - 0.5 * .data$prop) %>%
             dplyr::mutate(n = as.character(.data$n))
-
         }
       }
 
@@ -1910,33 +2191,37 @@ summary_donut_chart <- function(variants_tsv, plot_type = "ClinVar") {
         ggplot2::geom_bar(stat = "identity", color = "white") +
         ggplot2::coord_polar(theta = "y", start = 0) +
         ggplot2::geom_text(ggplot2::aes(y = 1 - .data$lab.ypos, label = .data$n),
-                           color = "white", family = "Helvetica", size = 6) +
+          color = "white", family = "Helvetica", size = 6
+        ) +
         ggplot2::scale_fill_manual(
           values = pcgrr::color_palette[["pathogenicity"]][["values"]],
           labels = pcgrr::color_palette[["pathogenicity"]][["levels"]],
-          drop = F) +
+          drop = F
+        ) +
         ggplot2::theme_void() +
         ggplot2::xlim(0.5, 2.5) +
         ggplot2::ggtitle(title) +
-        ggplot2::theme(plot.title =
-                         ggplot2::element_text(family = "Helvetica",
-                                               size = 16, vjust = -1,
-                                               hjust = 0.5),
-                       legend.title = ggplot2::element_blank(),
-                       plot.margin = ggplot2::margin(0, 0, 0, 0, "cm"),
-                       legend.text = ggplot2::element_text(
-                         family = "Helvetica", size = 14))
+        ggplot2::theme(
+          plot.title =
+            ggplot2::element_text(
+              family = "Helvetica",
+              size = 16, vjust = -1,
+              hjust = 0.5
+            ),
+          legend.title = ggplot2::element_blank(),
+          plot.margin = ggplot2::margin(0, 0, 0, 0, "cm"),
+          legend.text = ggplot2::element_text(
+            family = "Helvetica", size = 14
+          )
+        )
     }
-
-
   }
   return(p)
-
 }
 
 
 #' Function that retrieves clinical evidence items (CIVIC, CGI) for
-#'somatic cancer variants
+#' somatic cancer variants
 #'
 #' @param sample_calls data frame with germline variant callset from
 #' query sample
@@ -1949,9 +2234,10 @@ summary_donut_chart <- function(variants_tsv, plot_type = "ClinVar") {
 get_germline_biomarkers <- function(sample_calls,
                                     colset = NULL,
                                     eitems = NULL) {
-
-    pcgrr::log4r_info(paste0("Matching variant set with existing genomic ",
-                    "biomarkers from CIViC (germline)"))
+  pcgrr::log4r_info(paste0(
+    "Matching variant set with existing genomic ",
+    "biomarkers from CIViC (germline)"
+  ))
 
   clin_eitems_list <- list()
   for (type in c("diagnostic", "prognostic", "predictive", "predisposing")) {
@@ -1966,9 +2252,9 @@ get_germline_biomarkers <- function(sample_calls,
 
   sample_calls_p_lp <- sample_calls %>%
     dplyr::filter(!is.na(.data$CPSR_CLASSIFICATION) |
-                  !is.na(.data$CLINVAR_CLASSIFICATION)) %>%
+      !is.na(.data$CLINVAR_CLASSIFICATION)) %>%
     dplyr::filter(stringr::str_detect(.data$CPSR_CLASSIFICATION, "Pathogenic") |
-                  stringr::str_detect(.data$CLINVAR_CLASSIFICATION, "Pathogenic"))
+      stringr::str_detect(.data$CLINVAR_CLASSIFICATION, "Pathogenic"))
 
 
   ## match clinical evidence items against
@@ -1979,21 +2265,23 @@ get_germline_biomarkers <- function(sample_calls,
       db = "civic",
       colset = colset,
       eitems = eitems,
-      region_marker = F)
+      region_marker = F
+    )
 
 
   ## For evidence items reported at "regional level" - codon/exon/gene
   ## consider only pathogenic/likely pathogenic variants in the sample
   ## as candidates for match
   var_eitems_regional <- data.frame()
-  if(nrow(sample_calls_p_lp) > 0){
+  if (nrow(sample_calls_p_lp) > 0) {
     var_eitems_regional <-
       pcgrr::match_eitems_to_var(
         sample_calls_p_lp,
         db = "civic",
         colset = colset,
         eitems = eitems,
-        region_marker = T)
+        region_marker = T
+      )
   }
 
   ## for regional biomarkers - perform additional quality checks
@@ -2003,8 +2291,10 @@ get_germline_biomarkers <- function(sample_calls,
   for (m in c("codon", "exon", "gene")) {
     if (nrow(var_eitems_regional) > 0) {
       var_eitems[[m]] <-
-        pcgrr::qc_var_eitems(var_eitems = var_eitems_regional,
-                             marker_type = m)
+        pcgrr::qc_var_eitems(
+          var_eitems = var_eitems_regional,
+          marker_type = m
+        )
     }
   }
 
@@ -2012,24 +2302,34 @@ get_germline_biomarkers <- function(sample_calls,
     var_eitems = var_eitems,
     target_type = "exact",
     target_other =
-      c("codon", "exon", "gene"))
+      c("codon", "exon", "gene")
+  )
 
   var_eitems <- pcgrr::deduplicate_eitems(
     var_eitems = var_eitems,
     target_type = "codon",
     target_other =
-      c("exon", "gene"))
+      c("exon", "gene")
+  )
 
   ## log the types and number of clinical
   ## evidence items found (exact / codon / exon)
-  pcgrr::log_var_eitem_stats(var_eitems = var_eitems,
-                             target_type = "exact")
-  pcgrr::log_var_eitem_stats(var_eitems = var_eitems,
-                             target_type = "codon")
-  pcgrr::log_var_eitem_stats(var_eitems = var_eitems,
-                             target_type = "exon")
-  pcgrr::log_var_eitem_stats(var_eitems = var_eitems,
-                             target_type = "gene")
+  pcgrr::log_var_eitem_stats(
+    var_eitems = var_eitems,
+    target_type = "exact"
+  )
+  pcgrr::log_var_eitem_stats(
+    var_eitems = var_eitems,
+    target_type = "codon"
+  )
+  pcgrr::log_var_eitem_stats(
+    var_eitems = var_eitems,
+    target_type = "exon"
+  )
+  pcgrr::log_var_eitem_stats(
+    var_eitems = var_eitems,
+    target_type = "gene"
+  )
 
   all_var_evidence_items <- all_var_evidence_items %>%
     dplyr::bind_rows(var_eitems[["exact"]]) %>%
@@ -2046,14 +2346,16 @@ get_germline_biomarkers <- function(sample_calls,
       clin_eitems_list[[type]] <- all_var_evidence_items %>%
         dplyr::filter(.data$EVIDENCE_TYPE == stringr::str_to_title(type)) %>%
         dplyr::arrange(.data$EVIDENCE_LEVEL, .data$RATING) %>%
-        dplyr::select(.data$SYMBOL, .data$GENE_NAME,
-                      .data$CANCER_TYPE, .data$CLINICAL_SIGNIFICANCE,
-                      .data$EVIDENCE_LEVEL, .data$RATING,
-                      .data$EVIDENCE_DIRECTION, .data$CITATION,
-                      .data$THERAPEUTIC_CONTEXT, .data$EVIDENCE_TYPE,
-                      .data$DESCRIPTION, .data$BIOMARKER_MAPPING,
-                      .data$CDS_CHANGE, .data$LOSS_OF_FUNCTION,
-                      .data$GENOMIC_CHANGE) %>%
+        dplyr::select(
+          .data$SYMBOL, .data$GENE_NAME,
+          .data$CANCER_TYPE, .data$CLINICAL_SIGNIFICANCE,
+          .data$EVIDENCE_LEVEL, .data$RATING,
+          .data$EVIDENCE_DIRECTION, .data$CITATION,
+          .data$THERAPEUTIC_CONTEXT, .data$EVIDENCE_TYPE,
+          .data$DESCRIPTION, .data$BIOMARKER_MAPPING,
+          .data$CDS_CHANGE, .data$LOSS_OF_FUNCTION,
+          .data$GENOMIC_CHANGE
+        ) %>%
         dplyr::distinct()
     }
   }

--- a/inst/templates/cpsr_rmarkdown/cpsr_biomarkers.Rmd
+++ b/inst/templates/cpsr_rmarkdown/cpsr_biomarkers.Rmd
@@ -15,25 +15,24 @@
 show_germline_filters <- list()
 missing_germline_items <- list()
 biomarker_present <- F
-for(type in c('diagnostic','prognostic','predictive','predisposing')){
+for (type in c("diagnostic", "prognostic", "predictive", "predisposing")) {
   show_germline_filters[[type]] <- F
   missing_germline_items[[type]] <- T
-  if(NROW(cps_report[['content']][['snv_indel']][['clin_eitem']][[type]]) > 0){
+  if (NROW(cps_report[["content"]][["snv_indel"]][["clin_eitem"]][[type]]) > 0) {
     show_germline_filters[[type]] <- T
     missing_germline_items[[type]] <- F
     biomarker_present <- T
   }
 }
-
 ```
 
 
 ```{r biomarker_note, echo=F, results = "asis", include = biomarker_present}
 
-cat('<b>NOTE:</b> Reported biomarkers in CIViC are mapped at different resolutions (i.e. filter <b>Biomarker mapping</b>). The accuracy of a match between variants in the tumor sample and the reported biomarkers will vary accordingly (highlighted by gene symbols with different color backgrounds):\n\n')
+cat("<b>NOTE:</b> Reported biomarkers in CIViC are mapped at different resolutions (i.e. filter <b>Biomarker mapping</b>). The accuracy of a match between variants in the tumor sample and the reported biomarkers will vary accordingly (highlighted by gene symbols with different color backgrounds):\n\n")
 
 cat('<ul><li>Biomarker match at the <mark style="background-color:black; font-weight:bold; color:white">exact variant/codon level</mark></li>')
-cat(paste0('<br><li>Biomarker match at the <mark style="background-color:', cps_report[['metadata']][['color_palette']][['warning']][['values']][1],'; color:white; font-weight:bold">exon/gene level</mark></li></ul>\n'))
+cat(paste0('<br><li>Biomarker match at the <mark style="background-color:', cps_report[["metadata"]][["color_palette"]][["warning"]][["values"]][1], '; color:white; font-weight:bold">exon/gene level</mark></li></ul>\n'))
 
 htmltools::br()
 ```
@@ -42,14 +41,14 @@ htmltools::br()
 
 
 ```{r active_tab_cpsr_predisposing, echo = F, results = "asis"}
-if(missing_germline_items[['predisposing']] == F | 
-   (missing_germline_items[['diagnostic']] == T & 
-    missing_germline_items[['prognostic']] == T &
-    missing_germline_items[['predictive']] == T)){
+if (missing_germline_items[["predisposing"]] == F |
+  (missing_germline_items[["diagnostic"]] == T &
+    missing_germline_items[["prognostic"]] == T &
+    missing_germline_items[["predictive"]] == T)) {
   cat("")
   cat("#### Predisposing {.active}")
   cat("")
-}else{
+} else {
   cat("")
   cat("#### Predisposing")
   cat("")
@@ -61,7 +60,7 @@ if(missing_germline_items[['predisposing']] == F |
 
 ```{r germline_predisposing, echo=F, results = 'asis', eval = show_germline_filters[['predisposing']]}
 
-variants_germline_predisposing_shared <- crosstalk::SharedData$new(cps_report[['content']][['snv_indel']][['clin_eitem']][['predisposing']])
+variants_germline_predisposing_shared <- crosstalk::SharedData$new(cps_report[["content"]][["snv_indel"]][["clin_eitem"]][["predisposing"]])
 crosstalk::bscols(
   list(
     crosstalk::filter_select("CANCER_TYPE", "Cancer type", variants_germline_predisposing_shared, ~CANCER_TYPE),
@@ -74,50 +73,62 @@ crosstalk::bscols(
   )
 )
 
-cat('The table below lists all variant-evidence item associations:',sep='\n')
+cat("The table below lists all variant-evidence item associations:", sep = "\n")
 htmltools::br()
 htmltools::br()
 
-DT::datatable(variants_germline_predisposing_shared, escape=F,extensions=c("Buttons","Responsive"), 
-              options = 
-                list(buttons = c('csv','excel'),
-                     pageLength = 6,
-                     dom = 'Bfrtip')) %>%
-  DT::formatStyle('EVIDENCE_LEVEL', 
-                  backgroundColor = DT::styleEqual(c('A: Validated', 
-                                                     'A: FDA/NCCN/ELN guidelines', 
-                                                     'B: Clinical evidence', 
-                                                     'B1: Clinical evidence: late trials', 
-                                                     'B2: Clinical evidence: early trials', 
-                                                     'C: Case study', 
-                                                     'D: Preclinical evidence', 
-                                                     'E: Indirect evidence'), 
-                                                   c("#009E73","#009E73","#56B4E9", 
-                                                     "#56B4E9","#56B4E9","#0072B2",
-                                                     "#E69F00", "#F0E442"))) %>%
-  DT::formatStyle(color="white", "SYMBOL", "BIOMARKER_MAPPING", fontWeight = 'bold', `text-align` = 'center',
-                  backgroundColor = DT::styleEqual(c('exact','codon','exon','gene'), 
-                                                   c('#000','#000',cps_report[['metadata']][['color_palette']][['warning']][['values']][1], cps_report[['metadata']][['color_palette']][['warning']][['values']][1])))
-
-
-
+DT::datatable(variants_germline_predisposing_shared,
+  escape = F, extensions = c("Buttons", "Responsive"),
+  options =
+    list(
+      buttons = c("csv", "excel"),
+      pageLength = 6,
+      dom = "Bfrtip"
+    )
+) %>%
+  DT::formatStyle("EVIDENCE_LEVEL",
+    backgroundColor = DT::styleEqual(
+      c(
+        "A: Validated",
+        "A: FDA/NCCN/ELN guidelines",
+        "B: Clinical evidence",
+        "B1: Clinical evidence: late trials",
+        "B2: Clinical evidence: early trials",
+        "C: Case study",
+        "D: Preclinical evidence",
+        "E: Indirect evidence"
+      ),
+      c(
+        "#009E73", "#009E73", "#56B4E9",
+        "#56B4E9", "#56B4E9", "#0072B2",
+        "#E69F00", "#F0E442"
+      )
+    )
+  ) %>%
+  DT::formatStyle(
+    color = "white", "SYMBOL", "BIOMARKER_MAPPING", fontWeight = "bold", `text-align` = "center",
+    backgroundColor = DT::styleEqual(
+      c("exact", "codon", "exon", "gene"),
+      c("#000", "#000", cps_report[["metadata"]][["color_palette"]][["warning"]][["values"]][1], cps_report[["metadata"]][["color_palette"]][["warning"]][["values"]][1])
+    )
+  )
 ```
 
 ```{r germline_predisposing_missing, echo=F, results = 'asis', eval = missing_germline_items[['predisposing']]}
-cat('<i>No variant-evidence item associations found.</i>',sep='\n')
-cat('\n')
+cat("<i>No variant-evidence item associations found.</i>", sep = "\n")
+cat("\n")
 ```
 
 <br><br><br>
 
 
 ```{r active_tab_cpsr_predictive, echo = F, results = "asis"}
-if(missing_germline_items[['predictive']] == F & 
-   missing_germline_items[['predisposing']] == T){
+if (missing_germline_items[["predictive"]] == F &
+  missing_germline_items[["predisposing"]] == T) {
   cat("")
   cat("#### Predictive {.active}")
   cat("")
-}else{
+} else {
   cat("")
   cat("#### Predictive")
   cat("")
@@ -129,7 +140,7 @@ if(missing_germline_items[['predictive']] == F &
 
 ```{r germline_predictive, echo=F, results = 'asis', eval = show_germline_filters[['predictive']]}
 
-variants_germline_predictive_shared <- crosstalk::SharedData$new(cps_report[['content']][['snv_indel']][['clin_eitem']][['predictive']])
+variants_germline_predictive_shared <- crosstalk::SharedData$new(cps_report[["content"]][["snv_indel"]][["clin_eitem"]][["predictive"]])
 crosstalk::bscols(
   list(
     crosstalk::filter_select("CANCER_TYPE", "Cancer type", variants_germline_predictive_shared, ~CANCER_TYPE),
@@ -143,49 +154,59 @@ crosstalk::bscols(
   )
 )
 
-cat('The table below lists all variant-evidence item associations:',sep='\n')
+cat("The table below lists all variant-evidence item associations:", sep = "\n")
 htmltools::br()
 htmltools::br()
 
-DT::datatable(variants_germline_predictive_shared, escape=F,extensions=c("Buttons","Responsive"), options=list(buttons = c('csv','excel'),
-                                                                                                               pageLength = 6, dom = 'Bfrtip')) %>%
-  DT::formatStyle('EVIDENCE_LEVEL', 
-                  backgroundColor = DT::styleEqual(c('A: Validated',
-                                                     'A: FDA/NCCN/ELN guidelines',
-                                                     'B: Clinical evidence',
-                                                     'B1: Clinical evidence: late trials',
-                                                     'B2: Clinical evidence: early trials',
-                                                     'C: Case study',
-                                                     'D: Preclinical evidence',
-                                                     'E: Indirect evidence'), 
-                                                   c("#009E73","#009E73","#56B4E9", 
-                                                     "#56B4E9","#56B4E9","#0072B2",
-                                                     "#E69F00", "#F0E442"))) %>%
-  DT::formatStyle(color="white", "SYMBOL", "BIOMARKER_MAPPING", 
-                  fontWeight = 'bold', `text-align` = 'center',
-                  backgroundColor = DT::styleEqual(c('exact','codon','exon','gene'), 
-                                                   c('#000','#000',cps_report[['metadata']][['color_palette']][['warning']][['values']][1], cps_report[['metadata']][['color_palette']][['warning']][['values']][1])))
-
-
-
+DT::datatable(variants_germline_predictive_shared, escape = F, extensions = c("Buttons", "Responsive"), options = list(
+  buttons = c("csv", "excel"),
+  pageLength = 6, dom = "Bfrtip"
+)) %>%
+  DT::formatStyle("EVIDENCE_LEVEL",
+    backgroundColor = DT::styleEqual(
+      c(
+        "A: Validated",
+        "A: FDA/NCCN/ELN guidelines",
+        "B: Clinical evidence",
+        "B1: Clinical evidence: late trials",
+        "B2: Clinical evidence: early trials",
+        "C: Case study",
+        "D: Preclinical evidence",
+        "E: Indirect evidence"
+      ),
+      c(
+        "#009E73", "#009E73", "#56B4E9",
+        "#56B4E9", "#56B4E9", "#0072B2",
+        "#E69F00", "#F0E442"
+      )
+    )
+  ) %>%
+  DT::formatStyle(
+    color = "white", "SYMBOL", "BIOMARKER_MAPPING",
+    fontWeight = "bold", `text-align` = "center",
+    backgroundColor = DT::styleEqual(
+      c("exact", "codon", "exon", "gene"),
+      c("#000", "#000", cps_report[["metadata"]][["color_palette"]][["warning"]][["values"]][1], cps_report[["metadata"]][["color_palette"]][["warning"]][["values"]][1])
+    )
+  )
 ```
 
 ```{r germline_predictive_missing, echo=F, results = 'asis', eval = missing_germline_items[['predictive']]}
-cat('<i>No variant-evidence item associations found.</i>',sep='\n')
-cat('\n')
+cat("<i>No variant-evidence item associations found.</i>", sep = "\n")
+cat("\n")
 ```
 
 <br><br><br>
 
 
 ```{r active_tab_cpsr_prognostic, echo = F, results = "asis"}
-if(missing_germline_items[['prognostic']] == F & 
-   missing_germline_items[['predisposing']] == T & 
-   missing_germline_items[['predictive']] == T){
+if (missing_germline_items[["prognostic"]] == F &
+  missing_germline_items[["predisposing"]] == T &
+  missing_germline_items[["predictive"]] == T) {
   cat("")
   cat("#### Prognostic {.active}")
   cat("")
-}else{
+} else {
   cat("")
   cat("#### Prognostic")
   cat("")
@@ -197,7 +218,7 @@ if(missing_germline_items[['prognostic']] == F &
 
 ```{r germline_prognostic, echo=F, results='asis', eval = show_germline_filters[['prognostic']]}
 
-variants_germline_prognostic_shared <- crosstalk::SharedData$new(cps_report[['content']][['snv_indel']][['clin_eitem']][['prognostic']])
+variants_germline_prognostic_shared <- crosstalk::SharedData$new(cps_report[["content"]][["snv_indel"]][["clin_eitem"]][["prognostic"]])
 crosstalk::bscols(
   list(
     crosstalk::filter_select("SYMBOL", "Gene", variants_germline_prognostic_shared, ~SYMBOL),
@@ -209,48 +230,59 @@ crosstalk::bscols(
     crosstalk::filter_select("BIOMARKER_MAPPING", "Biomarker mapping", variants_germline_prognostic_shared, ~BIOMARKER_MAPPING)
   )
 )
-cat('The table below lists all variant-evidence item associations:',sep='\n')
+cat("The table below lists all variant-evidence item associations:", sep = "\n")
 htmltools::br()
 htmltools::br()
 
-DT::datatable(variants_germline_prognostic_shared, escape=F,extensions=c("Buttons","Responsive"), options=list(buttons = c('csv','excel'), 
-                                                                                                               pageLength = 6, dom = 'Bfrtip')) %>%
-  DT::formatStyle('EVIDENCE_LEVEL', 
-                  backgroundColor = DT::styleEqual(c('A: Validated',
-                                                     'A: FDA/NCCN/ELN guidelines',
-                                                     'B: Clinical evidence',
-                                                     'B1: Clinical evidence: late trials',
-                                                     'B2: Clinical evidence: early trials',
-                                                     'C: Case study',
-                                                     'D: Preclinical evidence',
-                                                     'E: Indirect evidence'), 
-                                                   c("#009E73","#009E73","#56B4E9", 
-                                                     "#56B4E9","#56B4E9","#0072B2",
-                                                     "#E69F00", "#F0E442"))) %>%
-  DT::formatStyle(color="white", "SYMBOL", "BIOMARKER_MAPPING", 
-                  fontWeight = 'bold', `text-align` = 'center',
-                  backgroundColor = DT::styleEqual(c('exact','codon','exon','gene'),
-                                         c('#000','#000',cps_report[['metadata']][['color_palette']][['warning']][['values']][1], cps_report[['metadata']][['color_palette']][['warning']][['values']][1])))
-
-
+DT::datatable(variants_germline_prognostic_shared, escape = F, extensions = c("Buttons", "Responsive"), options = list(
+  buttons = c("csv", "excel"),
+  pageLength = 6, dom = "Bfrtip"
+)) %>%
+  DT::formatStyle("EVIDENCE_LEVEL",
+    backgroundColor = DT::styleEqual(
+      c(
+        "A: Validated",
+        "A: FDA/NCCN/ELN guidelines",
+        "B: Clinical evidence",
+        "B1: Clinical evidence: late trials",
+        "B2: Clinical evidence: early trials",
+        "C: Case study",
+        "D: Preclinical evidence",
+        "E: Indirect evidence"
+      ),
+      c(
+        "#009E73", "#009E73", "#56B4E9",
+        "#56B4E9", "#56B4E9", "#0072B2",
+        "#E69F00", "#F0E442"
+      )
+    )
+  ) %>%
+  DT::formatStyle(
+    color = "white", "SYMBOL", "BIOMARKER_MAPPING",
+    fontWeight = "bold", `text-align` = "center",
+    backgroundColor = DT::styleEqual(
+      c("exact", "codon", "exon", "gene"),
+      c("#000", "#000", cps_report[["metadata"]][["color_palette"]][["warning"]][["values"]][1], cps_report[["metadata"]][["color_palette"]][["warning"]][["values"]][1])
+    )
+  )
 ```
 
 ```{r germline_prognostic_missing, echo=F, results = 'asis', eval = missing_germline_items[['prognostic']]}
-cat('<i>No variant-evidence item associations found.</i>',sep='\n')
-cat('\n')
+cat("<i>No variant-evidence item associations found.</i>", sep = "\n")
+cat("\n")
 ```
 
 <br><br><br>
 
 ```{r active_tab_cpsr_diagnostic, echo = F, results = "asis"}
-if(missing_germline_items[['diagnostic']] == F &
-  missing_germline_items[['prognostic']] == T & 
-   missing_germline_items[['predisposing']] == T & 
-   missing_germline_items[['predictive']] == T){
+if (missing_germline_items[["diagnostic"]] == F &
+  missing_germline_items[["prognostic"]] == T &
+  missing_germline_items[["predisposing"]] == T &
+  missing_germline_items[["predictive"]] == T) {
   cat("")
   cat("#### Diagnostic {.active}")
   cat("")
-}else{
+} else {
   cat("")
   cat("#### Diagnostic")
   cat("")
@@ -262,49 +294,61 @@ if(missing_germline_items[['diagnostic']] == F &
 
 ```{r germline_diagnostic, echo=F, results='asis', eval = show_germline_filters[['diagnostic']]}
 
-variants_germline_diagnostic_shared <- crosstalk::SharedData$new(cps_report[['content']][['snv_indel']][['clin_eitem']][['diagnostic']])
+variants_germline_diagnostic_shared <- crosstalk::SharedData$new(cps_report[["content"]][["snv_indel"]][["clin_eitem"]][["diagnostic"]])
 crosstalk::bscols(
   list(
     crosstalk::filter_select("SYMBOL", "Gene", variants_germline_diagnostic_shared, ~SYMBOL),
     crosstalk::filter_select("CANCER_TYPE", "Cancer type", variants_germline_diagnostic_shared, ~CANCER_TYPE),
     crosstalk::filter_select("CLINICAL_SIGNIFICANCE", "Clinical association", variants_germline_diagnostic_shared, ~CLINICAL_SIGNIFICANCE)
-
   ),
   list(
     crosstalk::filter_select("EVIDENCE_LEVEL", "Evidence level", variants_germline_diagnostic_shared, ~EVIDENCE_LEVEL),
     crosstalk::filter_select("BIOMARKER_MAPPING", "Biomarker mapping", variants_germline_diagnostic_shared, ~BIOMARKER_MAPPING)
   )
 )
-cat('The table below lists all variant-evidence item associations:',sep='\n')
+cat("The table below lists all variant-evidence item associations:", sep = "\n")
 htmltools::br()
 htmltools::br()
 
-DT::datatable(variants_germline_diagnostic_shared, escape=F,extensions=c("Buttons","Responsive"), 
-              options=list(buttons = c('csv','excel'), 
-                           pageLength = 6, dom = 'Bfrtip')) %>%
-  DT::formatStyle('EVIDENCE_LEVEL', 
-                  backgroundColor = DT::styleEqual(c('A: Validated',
-                                                     'A: FDA/NCCN/ELN guidelines',
-                                                     'B: Clinical evidence',
-                                                     'B1: Clinical evidence: late trials',
-                                                     'B2: Clinical evidence: early trials',
-                                                     'C: Case study',
-                                                     'D: Preclinical evidence',
-                                                     'E: Indirect evidence'), 
-                                                   c("#009E73","#009E73","#56B4E9", 
-                                                     "#56B4E9","#56B4E9","#0072B2",
-                                                     "#E69F00", "#F0E442"))) %>%
-  DT::formatStyle(color="white", "SYMBOL", "BIOMARKER_MAPPING", 
-                  fontWeight = 'bold', `text-align` = 'center',
-                  backgroundColor = DT::styleEqual(c('exact','codon','exon','gene'),
-                                         c('#000','#000',cps_report[['metadata']][['color_palette']][['warning']][['values']][1], cps_report[['metadata']][['color_palette']][['warning']][['values']][1])))
-
-
+DT::datatable(variants_germline_diagnostic_shared,
+  escape = F, extensions = c("Buttons", "Responsive"),
+  options = list(
+    buttons = c("csv", "excel"),
+    pageLength = 6, dom = "Bfrtip"
+  )
+) %>%
+  DT::formatStyle("EVIDENCE_LEVEL",
+    backgroundColor = DT::styleEqual(
+      c(
+        "A: Validated",
+        "A: FDA/NCCN/ELN guidelines",
+        "B: Clinical evidence",
+        "B1: Clinical evidence: late trials",
+        "B2: Clinical evidence: early trials",
+        "C: Case study",
+        "D: Preclinical evidence",
+        "E: Indirect evidence"
+      ),
+      c(
+        "#009E73", "#009E73", "#56B4E9",
+        "#56B4E9", "#56B4E9", "#0072B2",
+        "#E69F00", "#F0E442"
+      )
+    )
+  ) %>%
+  DT::formatStyle(
+    color = "white", "SYMBOL", "BIOMARKER_MAPPING",
+    fontWeight = "bold", `text-align` = "center",
+    backgroundColor = DT::styleEqual(
+      c("exact", "codon", "exon", "gene"),
+      c("#000", "#000", cps_report[["metadata"]][["color_palette"]][["warning"]][["values"]][1], cps_report[["metadata"]][["color_palette"]][["warning"]][["values"]][1])
+    )
+  )
 ```
 
 ```{r germline_diagnostic_missing, echo=F, results = 'asis', eval = missing_germline_items[['diagnostic']]}
-cat('<i>No variant-evidence item associations found.</i>',sep='\n')
-cat('\n')
+cat("<i>No variant-evidence item associations found.</i>", sep = "\n")
+cat("\n")
 ```
 
 <br><br><br>

--- a/inst/templates/cpsr_rmarkdown/cpsr_documentation.Rmd
+++ b/inst/templates/cpsr_rmarkdown/cpsr_documentation.Rmd
@@ -20,31 +20,29 @@ The analysis performed in the cancer genome report is based on the following und
 
 * __Software__ 
 ```{r list_software, echo=F,results='asis'}
-for(n in names(cps_report$metadata$pcgr_db_release)){
-  if(n == 'mosdepth' | n == 'mutationalpatterns' | n == 'vcf2maf' | n == 'bundle_version'){
+for (n in names(cps_report$metadata$pcgr_db_release)) {
+  if (n == "mosdepth" | n == "mutationalpatterns" | n == "vcf2maf" | n == "bundle_version") {
     next
   }
-  if(cps_report$metadata$pcgr_db_release[[n]]$resource_type == 'software'){
-    s <- paste0('    * [',cps_report$metadata$pcgr_db_release[[n]]$name,'](',cps_report$metadata$pcgr_db_release[[n]]$url,') - ',cps_report$metadata$pcgr_db_release[[n]]$description, ' (',cps_report$metadata$pcgr_db_release[[n]]$version,')')
-    cat(s,sep="\n")
+  if (cps_report$metadata$pcgr_db_release[[n]]$resource_type == "software") {
+    s <- paste0("    * [", cps_report$metadata$pcgr_db_release[[n]]$name, "](", cps_report$metadata$pcgr_db_release[[n]]$url, ") - ", cps_report$metadata$pcgr_db_release[[n]]$description, " (", cps_report$metadata$pcgr_db_release[[n]]$version, ")")
+    cat(s, sep = "\n")
   }
 }
-
 ```
 <br><br>
 
 * __Databases/datasets__ 
 ```{r list_db, echo=F,results='asis'}
-for(n in names(cps_report$metadata$pcgr_db_release)){
-  if(cps_report$metadata$pcgr_db_release[[n]]$resource_type != 'software'){
-    if(n != 'cbmdb' & n != 'chembl' & n != 'corum' & n != 'icgc' & n != 'bundle_version' & n != 'tcga' & n != 'cosmic' & n != 'dgidb' & n != 'ct' & 
-       n != 'kegg' & n != 'onekg' &  n != 'tcga-pcdm' & n != 'opentargets'){
-      s <- paste0('    * [',cps_report$metadata$pcgr_db_release[[n]]$name,'](',cps_report$metadata$pcgr_db_release[[n]]$url,') - ',cps_report$metadata$pcgr_db_release[[n]]$description, ' (',cps_report$metadata$pcgr_db_release[[n]]$version,')')
-      cat(s,sep="\n")
+for (n in names(cps_report$metadata$pcgr_db_release)) {
+  if (cps_report$metadata$pcgr_db_release[[n]]$resource_type != "software") {
+    if (n != "cbmdb" & n != "chembl" & n != "corum" & n != "icgc" & n != "bundle_version" & n != "tcga" & n != "cosmic" & n != "dgidb" & n != "ct" &
+      n != "kegg" & n != "onekg" & n != "tcga-pcdm" & n != "opentargets") {
+      s <- paste0("    * [", cps_report$metadata$pcgr_db_release[[n]]$name, "](", cps_report$metadata$pcgr_db_release[[n]]$url, ") - ", cps_report$metadata$pcgr_db_release[[n]]$description, " (", cps_report$metadata$pcgr_db_release[[n]]$version, ")")
+      cat(s, sep = "\n")
     }
   }
 }
-
 ```
 
 ### Variant classification
@@ -72,21 +70,28 @@ In the table below, a detailed description of all evidence criteria that are cur
 
 
 ```{r acmg_evidence, echo = F, eval = T}
-data <- dplyr::filter(pcgrr::cpsr_acmg[['evidence_codes']], 
-                      cpsr_evidence_code != 'ACMG_BS2_1' & 
-                        cpsr_evidence_code != 'ACMG_BS2_2' & 
-                        cpsr_evidence_code != 'ACMG_BS2_3') %>% 
-  dplyr::select(-category) %>% 
-  dplyr::rename(pole = pathogenicity_pole, category = category_long, score = path_score) %>% 
+data <- dplyr::filter(
+  pcgrr::cpsr_acmg[["evidence_codes"]],
+  cpsr_evidence_code != "ACMG_BS2_1" &
+    cpsr_evidence_code != "ACMG_BS2_2" &
+    cpsr_evidence_code != "ACMG_BS2_3"
+) %>%
+  dplyr::select(-category) %>%
+  dplyr::rename(pole = pathogenicity_pole, category = category_long, score = path_score) %>%
   dplyr::arrange(pole)
 
-DT::datatable(data, escape=F, extensions=c("Buttons","Responsive"), 
-                options = list(
-                  pageLength = 10,
-                  buttons = c('csv','excel'),
-                  dom = 'Bfrtip')) %>%
-  DT::formatStyle("cpsr_evidence_code","pole", color = "white", 
-                  backgroundColor = DT::styleEqual(c('P','B'), c('#9E0142','#077009')))
+DT::datatable(data,
+  escape = F, extensions = c("Buttons", "Responsive"),
+  options = list(
+    pageLength = 10,
+    buttons = c("csv", "excel"),
+    dom = "Bfrtip"
+  )
+) %>%
+  DT::formatStyle("cpsr_evidence_code", "pole",
+    color = "white",
+    backgroundColor = DT::styleEqual(c("P", "B"), c("#9E0142", "#077009"))
+  )
 ```
 
 

--- a/inst/templates/cpsr_rmarkdown/cpsr_gwas.Rmd
+++ b/inst/templates/cpsr_rmarkdown/cpsr_gwas.Rmd
@@ -6,56 +6,56 @@
 
 show_gwas_filters <- F
 missing_gwas_items <- T
-if(NROW(cps_report[['content']][['snv_indel']][["disp"]][['gwas']]) > 0){
+if (NROW(cps_report[["content"]][["snv_indel"]][["disp"]][["gwas"]]) > 0) {
   show_gwas_filters <- T
   missing_gwas_items <- F
 }
- 
-tag_gnomad <- cps_report[['metadata']][['config']][['popgen']][['vcftag_gnomad']]
-desc_gnomad <- cps_report[['metadata']][['config']][['popgen']][['popdesc_gnomad']]
-formula_gnomad <- as.formula(paste0("~",rlang::sym(tag_gnomad)))
 
+tag_gnomad <- cps_report[["metadata"]][["config"]][["popgen"]][["vcftag_gnomad"]]
+desc_gnomad <- cps_report[["metadata"]][["config"]][["popgen"]][["popdesc_gnomad"]]
+formula_gnomad <- as.formula(paste0("~", rlang::sym(tag_gnomad)))
 ```
 
 ```{r gwas_cancer, echo=F, results = 'asis', eval = show_gwas_filters}
 
-cat('A total of ',NROW(cps_report[['content']][['snv_indel']][["disp"]][['gwas']]), ' other germline variant(s) in the query VCF are associated with cancer phenotypes, as found through [genome-wide association studies](https://www.ebi.ac.uk/gwas/) (p-value < ',cps_report[['metadata']][['config']][['gwas']][['p_value_min']],'):')
-cat('\n')
+cat("A total of ", NROW(cps_report[["content"]][["snv_indel"]][["disp"]][["gwas"]]), " other germline variant(s) in the query VCF are associated with cancer phenotypes, as found through [genome-wide association studies](https://www.ebi.ac.uk/gwas/) (p-value < ", cps_report[["metadata"]][["config"]][["gwas"]][["p_value_min"]], "):")
+cat("\n")
 htmltools::br()
 htmltools::br()
 
-variants_gwas_cancer <- crosstalk::SharedData$new(cps_report[['content']][['snv_indel']][["disp"]][['gwas']])
+variants_gwas_cancer <- crosstalk::SharedData$new(cps_report[["content"]][["snv_indel"]][["disp"]][["gwas"]])
 crosstalk::bscols(
   list(
     crosstalk::filter_select("CONSEQUENCE", "Consequence", variants_gwas_cancer, ~CONSEQUENCE),
     crosstalk::filter_checkbox("GENOTYPE", "Genotype", variants_gwas_cancer, ~GENOTYPE),
     crosstalk::filter_select("SYMBOL", "Gene", variants_gwas_cancer, ~SYMBOL),
     crosstalk::filter_select("GWAS_PHENOTYPE", "GWAS phenotype", variants_gwas_cancer, ~GWAS_PHENOTYPE)
-
   ),
   list(
-    crosstalk::filter_slider("GLOBAL_AF_GNOMAD", "MAF gnomAD", variants_gwas_cancer, ~GLOBAL_AF_GNOMAD, sep="",ticks = F),
-     crosstalk::filter_slider("GERP_SCORE","Genomic conservation score (GERP)",variants_gwas_cancer, ~GERP_SCORE,
-                             min = -12.3, max = 6.17, ticks = T),
+    crosstalk::filter_slider("GLOBAL_AF_GNOMAD", "MAF gnomAD", variants_gwas_cancer, ~GLOBAL_AF_GNOMAD, sep = "", ticks = F),
+    crosstalk::filter_slider("GERP_SCORE", "Genomic conservation score (GERP)", variants_gwas_cancer, ~GERP_SCORE,
+      min = -12.3, max = 6.17, ticks = T
+    ),
     crosstalk::filter_select("miRNA_TARGET_HIT", "miRNA target gain/loss", variants_gwas_cancer, ~miRNA_TARGET_HIT),
     crosstalk::filter_select("TF_BINDING_SITE_VARIANT", "TF binding site alteration", variants_gwas_cancer, ~TF_BINDING_SITE_VARIANT)
   )
 )
 
-    
+
 htmltools::br()
 htmltools::br()
 
-DT::datatable(variants_gwas_cancer, escape=F,extensions=c("Buttons","Responsive"), 
-              options=list(buttons = c('csv','excel'),dom = 'Bfrtip'))
+DT::datatable(variants_gwas_cancer,
+  escape = F, extensions = c("Buttons", "Responsive"),
+  options = list(buttons = c("csv", "excel"), dom = "Bfrtip")
+)
 
 
-#htmltools::br()
-
+# htmltools::br()
 ```
 
 ```{r gwas_cancer_missing, echo=F, results = 'asis', eval = missing_gwas_items}
-cat('<i>No GWAS variants with a p-value <',cps_report[['metadata']][['config']][['gwas']][['p_value_min']],' were found.</i>',sep='\n')
-cat('\n')
+cat("<i>No GWAS variants with a p-value <", cps_report[["metadata"]][["config"]][["gwas"]][["p_value_min"]], " were found.</i>", sep = "\n")
+cat("\n")
 ```
 <br><br>

--- a/inst/templates/cpsr_rmarkdown/cpsr_secondary_findings.Rmd
+++ b/inst/templates/cpsr_rmarkdown/cpsr_secondary_findings.Rmd
@@ -5,8 +5,7 @@
 
 ```{r prepare_sf_data, echo=F, results='asis'}
 
-tot_variants_p_clinvar <- NROW(cps_report[['content']][['snv_indel']][["disp"]][['secondary']])
-
+tot_variants_p_clinvar <- NROW(cps_report[["content"]][["snv_indel"]][["disp"]][["secondary"]])
 ```
 
 *  In the sample, a total of n = __`r tot_variants_p_clinvar`__ variants in [genes recommended for secondary findings reporting (ACMG v3.0)](https://www.nature.com/articles/s41436-021-01172-3) 
@@ -19,17 +18,18 @@ are registered with a <i>Pathogenic/Likely pathogenic</i> clinical significance 
 htmltools::br()
 htmltools::br()
 
-DT::datatable(cps_report[['content']][['snv_indel']][["disp"]][['secondary']], 
-              escape=F,extensions=c("Buttons","Responsive"), 
-              options = list(
-                pageLength = 6,
-                buttons = c('csv','excel'),
-                dom = 'Bfrtip',
-                initComplete = DT::JS(
-                  "function(settings, json) {",
-                  "$(this.api().table().header()).css({'background-color': '#8E9092', 'color': '#fff'});",
-                  "}")
-              )
+DT::datatable(cps_report[["content"]][["snv_indel"]][["disp"]][["secondary"]],
+  escape = F, extensions = c("Buttons", "Responsive"),
+  options = list(
+    pageLength = 6,
+    buttons = c("csv", "excel"),
+    dom = "Bfrtip",
+    initComplete = DT::JS(
+      "function(settings, json) {",
+      "$(this.api().table().header()).css({'background-color': '#8E9092', 'color': '#fff'});",
+      "}"
+    )
+  )
 )
 
 htmltools::br()

--- a/inst/templates/cpsr_rmarkdown/cpsr_settings.Rmd
+++ b/inst/templates/cpsr_rmarkdown/cpsr_settings.Rmd
@@ -4,19 +4,20 @@
 
 gencode_versions <- unlist(stringr::str_split_fixed(
   stringr::str_replace(
-    cps_report$metadata$pcgr_db_release$gencode$version,"release ",""),
-  "/", 2))[1,]
-  
+    cps_report$metadata$pcgr_db_release$gencode$version, "release ", ""
+  ),
+  "/", 2
+))[1, ]
+
 gencode_version <- gencode_versions[2]
-if(cps_report[['metadata']][['genome_assembly']] == "grch38"){
+if (cps_report[["metadata"]][["genome_assembly"]] == "grch38") {
   gencode_version <- gencode_versions[1]
 }
 
-transcript_set_gencode <- paste0("GENCODE - basic set (v", gencode_version,")")
-if(cps_report[['metadata']][['config']][['other']][['vep_gencode_all']] == T){
-  transcript_set_gencode <- paste0("GENCODE - all transcripts (v", gencode_version,")")
+transcript_set_gencode <- paste0("GENCODE - basic set (v", gencode_version, ")")
+if (cps_report[["metadata"]][["config"]][["other"]][["vep_gencode_all"]] == T) {
+  transcript_set_gencode <- paste0("GENCODE - all transcripts (v", gencode_version, ")")
 }
-
 ```
 
 ### Sample metadata

--- a/inst/templates/cpsr_rmarkdown/cpsr_summary.Rmd
+++ b/inst/templates/cpsr_rmarkdown/cpsr_summary.Rmd
@@ -7,17 +7,16 @@ p1 <- cpsr::summary_donut_chart(cps_report$content$snv_indel$variant_set$tsv, pl
 p2 <- cpsr::summary_donut_chart(cps_report$content$snv_indel$variant_set$tsv, plot_type = "Other")
 
 p <- NULL
-if(!is.null(p1) & !is.null(p2)){
-  p <- ggpubr::ggarrange(p1, p2, labels = c("",""), ncol = 2, nrow = 1)
+if (!is.null(p1) & !is.null(p2)) {
+  p <- ggpubr::ggarrange(p1, p2, labels = c("", ""), ncol = 2, nrow = 1)
 }
-if(!is.null(p1) & is.null(p2)){
-  p  = p1
+if (!is.null(p1) & is.null(p2)) {
+  p <- p1
 }
-if(is.null(p1) & !is.null(p2)){
+if (is.null(p1) & !is.null(p2)) {
   p <- p2
 }
 p
-
 ```
 
 

--- a/inst/templates/cpsr_rmarkdown/cpsr_tiers.Rmd
+++ b/inst/templates/cpsr_rmarkdown/cpsr_tiers.Rmd
@@ -9,31 +9,28 @@ dtable_scrollY <- "700px"
 show_class_filters <- list()
 missing_class_items <- list()
 tot_variants <- list()
-for(c in c('class1','class2','class3','class4','class5')){
+for (c in c("class1", "class2", "class3", "class4", "class5")) {
   show_class_filters[[c]] <- list()
   missing_class_items[[c]] <- list()
   tot_variants[[c]] <- list()
-  for(m in c('Other','ClinVar')){
+  for (m in c("Other", "ClinVar")) {
     tot_variants[[c]][[m]] <- 0
     show_class_filters[[c]][[m]] <- F
     missing_class_items[[c]][[m]] <- T
-    if(NROW(cps_report[['content']][['snv_indel']][["disp"]][[c]]) > 0){
-      tot_variants[[c]][[m]] <- NROW(cps_report[['content']][['snv_indel']][["disp"]][[c]] %>% 
-                                     dplyr::filter(CPSR_CLASSIFICATION_SOURCE == m))
+    if (NROW(cps_report[["content"]][["snv_indel"]][["disp"]][[c]]) > 0) {
+      tot_variants[[c]][[m]] <- NROW(cps_report[["content"]][["snv_indel"]][["disp"]][[c]] %>%
+        dplyr::filter(CPSR_CLASSIFICATION_SOURCE == m))
     }
-    if(tot_variants[[c]][[m]] > 0){
+    if (tot_variants[[c]][[m]] > 0) {
       show_class_filters[[c]][[m]] <- T
       missing_class_items[[c]][[m]] <- F
     }
   }
 }
 
-tag_gnomad <- cps_report[['metadata']][['config']][['popgen']][['vcftag_gnomad']]
-desc_gnomad <- cps_report[['metadata']][['config']][['popgen']][['popdesc_gnomad']]
-formula_gnomad <- as.formula(paste0("~",rlang::sym(tag_gnomad)))
-
-
-
+tag_gnomad <- cps_report[["metadata"]][["config"]][["popgen"]][["vcftag_gnomad"]]
+desc_gnomad <- cps_report[["metadata"]][["config"]][["popgen"]][["popdesc_gnomad"]]
+formula_gnomad <- as.formula(paste0("~", rlang::sym(tag_gnomad)))
 ```
 
 
@@ -52,11 +49,11 @@ formula_gnomad <- as.formula(paste0("~",rlang::sym(tag_gnomad)))
 
 
 ```{r active_tab_class5, echo = F, results = "asis"}
-if(missing_class_items[['class5']][['ClinVar']] == F | (missing_class_items[['class5']][['Other']] == T & missing_class_items[['class5']][['ClinVar']] == T)){
+if (missing_class_items[["class5"]][["ClinVar"]] == F | (missing_class_items[["class5"]][["Other"]] == T & missing_class_items[["class5"]][["ClinVar"]] == T)) {
   cat("")
   cat("#### ClinVar {.active}")
   cat("")
-}else{
+} else {
   cat("")
   cat("#### ClinVar")
   cat("")
@@ -66,23 +63,25 @@ if(missing_class_items[['class5']][['ClinVar']] == F | (missing_class_items[['cl
 
 ```{r class5_cpsr_clinvar, echo=F, results = 'asis', eval = show_class_filters[['class5']][['ClinVar']]}
 
-cat('\n')
+cat("\n")
 htmltools::br()
 
 
-variants_class5_clinvar <- 
-  dplyr::filter(cps_report[['content']][['snv_indel']][["disp"]][['class5']], CPSR_CLASSIFICATION_SOURCE == 'ClinVar')
+variants_class5_clinvar <-
+  dplyr::filter(cps_report[["content"]][["snv_indel"]][["disp"]][["class5"]], CPSR_CLASSIFICATION_SOURCE == "ClinVar")
 
-if(NROW(variants_class5_clinvar) > 2000){
-  cat('<b>NOTE - only considering top 2000 variants (due to limitations with client-side tables) </b><br>',sep="\n")
-  cat('<br>')
-  variants_class5_clinvar <- 
+if (NROW(variants_class5_clinvar) > 2000) {
+  cat("<b>NOTE - only considering top 2000 variants (due to limitations with client-side tables) </b><br>", sep = "\n")
+  cat("<br>")
+  variants_class5_clinvar <-
     head(variants_class5_clinvar, 2000)
 }
 
-variants_class5_clinvar <- variants_class5_clinvar %>% 
-  dplyr::select(-c(CPSR_CLASSIFICATION,CPSR_PATHOGENICITY_SCORE,
-                   CPSR_CLASSIFICATION_DOC,CPSR_CLASSIFICATION_CODE))
+variants_class5_clinvar <- variants_class5_clinvar %>%
+  dplyr::select(-c(
+    CPSR_CLASSIFICATION, CPSR_PATHOGENICITY_SCORE,
+    CPSR_CLASSIFICATION_DOC, CPSR_CLASSIFICATION_CODE
+  ))
 
 variants_class5_1 <- crosstalk::SharedData$new(variants_class5_clinvar)
 crosstalk::bscols(
@@ -95,43 +94,43 @@ crosstalk::bscols(
     crosstalk::filter_select("CLINVAR_PHENOTYPE", "ClinVar phenotype(s)", variants_class5_1, ~CLINVAR_PHENOTYPE),
     crosstalk::filter_slider("CLINVAR_REVIEW_STATUS_STARS", "ClinVar review status stars", variants_class5_1, ~CLINVAR_REVIEW_STATUS_STARS, min = 0, max = 4, step = 1, ticks = T),
     crosstalk::filter_select("CLINVAR_CONFLICTED", "ClinVar conflicting interpretations", variants_class5_1, ~CLINVAR_CONFLICTED),
-    crosstalk::filter_slider(tag_gnomad, paste0("MAF gnomAD (",desc_gnomad,")"), variants_class5_1, formula_gnomad, sep="",ticks = F)
+    crosstalk::filter_slider(tag_gnomad, paste0("MAF gnomAD (", desc_gnomad, ")"), variants_class5_1, formula_gnomad, sep = "", ticks = F)
   )
 )
 
-    
+
 
 htmltools::br()
 htmltools::br()
 
-DT::datatable(variants_class5_1, escape=F,extensions=c("Buttons","Responsive"),
-              options = list(
-                pageLength = dtable_pageLength,
-                #scrollY = dtable_scrollY,
-                scrollCollapse = T,
-                #autoWidth = T,
-                buttons = c('csv','excel'),
-                dom = 'Bfrtip',
-                initComplete = DT::JS(
-                  "function(settings, json) {",
-                  "$(this.api().table().header()).css({'background-color':'#9E0142', 'color': '#fff'});",
-                  "}")
-              )
+DT::datatable(variants_class5_1,
+  escape = F, extensions = c("Buttons", "Responsive"),
+  options = list(
+    pageLength = dtable_pageLength,
+    # scrollY = dtable_scrollY,
+    scrollCollapse = T,
+    # autoWidth = T,
+    buttons = c("csv", "excel"),
+    dom = "Bfrtip",
+    initComplete = DT::JS(
+      "function(settings, json) {",
+      "$(this.api().table().header()).css({'background-color':'#9E0142', 'color': '#fff'});",
+      "}"
+    )
+  )
 )
 
 htmltools::br()
 htmltools::br()
 htmltools::br()
-
-
 ```
 
 ```{r active2_tab_class5, echo = F, results = "asis"}
-if(missing_class_items[['class5']][['ClinVar']] == T & missing_class_items[['class5']][['Other']] == F){
+if (missing_class_items[["class5"]][["ClinVar"]] == T & missing_class_items[["class5"]][["Other"]] == F) {
   cat("")
   cat("#### Non-ClinVar {.active}")
   cat("")
-}else{
+} else {
   cat("")
   cat("#### Non-ClinVar")
   cat("")
@@ -141,19 +140,21 @@ if(missing_class_items[['class5']][['ClinVar']] == T & missing_class_items[['cla
 
 ```{r class5_cpsr_other, echo=F, results = 'asis', eval = show_class_filters[['class5']][['Other']]}
 
-variants_class5_other <- 
-  dplyr::filter(cps_report[['content']][['snv_indel']][["disp"]][['class5']], CPSR_CLASSIFICATION_SOURCE == 'Other')
+variants_class5_other <-
+  dplyr::filter(cps_report[["content"]][["snv_indel"]][["disp"]][["class5"]], CPSR_CLASSIFICATION_SOURCE == "Other")
 
-if(NROW(variants_class5_other) > 2000){
-  cat('<b>NOTE - only considering top 2000 variants (ranked according to CPSR classification score) </b><br>',sep="\n")
-  cat('<br>')
-  variants_class5_other <- 
+if (NROW(variants_class5_other) > 2000) {
+  cat("<b>NOTE - only considering top 2000 variants (ranked according to CPSR classification score) </b><br>", sep = "\n")
+  cat("<br>")
+  variants_class5_other <-
     head(variants_class5_other, 2000)
 }
 
-variants_class5_other <- variants_class5_other %>% 
-  dplyr::select(-c(CLINVAR, CLINVAR_REVIEW_STATUS_STARS, CLINVAR_VARIANT_ORIGIN, 
-                   CLINVAR_CLASSIFICATION, CLINVAR_CONFLICTED, CLINVAR_PHENOTYPE))
+variants_class5_other <- variants_class5_other %>%
+  dplyr::select(-c(
+    CLINVAR, CLINVAR_REVIEW_STATUS_STARS, CLINVAR_VARIANT_ORIGIN,
+    CLINVAR_CLASSIFICATION, CLINVAR_CONFLICTED, CLINVAR_PHENOTYPE
+  ))
 
 
 variants_class5_2 <- crosstalk::SharedData$new(variants_class5_other)
@@ -166,33 +167,34 @@ crosstalk::bscols(
   list(
     crosstalk::filter_select("CPSR_CLASSIFICATION_CODE", "CPSR classification (ACMG criteria codes)", variants_class5_2, ~CPSR_CLASSIFICATION_CODE),
     crosstalk::filter_slider("CPSR_PATHOGENICITY_SCORE", "CPSR pathogenicity score", variants_class5_2, ~CPSR_PATHOGENICITY_SCORE, step = 0.5, ticks = T),
-    crosstalk::filter_slider(tag_gnomad, paste0("MAF gnomAD (",desc_gnomad,")"), variants_class5_2, formula_gnomad, sep="",ticks = F)
+    crosstalk::filter_slider(tag_gnomad, paste0("MAF gnomAD (", desc_gnomad, ")"), variants_class5_2, formula_gnomad, sep = "", ticks = F)
   )
 )
 
-    
+
 
 htmltools::br()
 htmltools::br()
 
-DT::datatable(variants_class5_2, escape=F,extensions=c("Buttons","Responsive"), 
-              options = list(
-                 pageLength = dtable_pageLength,
-                  #scrollY = dtable_scrollY,
-                  scrollCollapse = T,
-                buttons = c('csv','excel'),
-                dom = 'Bfrtip',
-                initComplete = DT::JS(
-                  "function(settings, json) {",
-                  "$(this.api().table().header()).css({'background-color':'#9E0142', 'color': '#fff'});",
-                  "}")
-              )
+DT::datatable(variants_class5_2,
+  escape = F, extensions = c("Buttons", "Responsive"),
+  options = list(
+    pageLength = dtable_pageLength,
+    # scrollY = dtable_scrollY,
+    scrollCollapse = T,
+    buttons = c("csv", "excel"),
+    dom = "Bfrtip",
+    initComplete = DT::JS(
+      "function(settings, json) {",
+      "$(this.api().table().header()).css({'background-color':'#9E0142', 'color': '#fff'});",
+      "}"
+    )
+  )
 )
 
 htmltools::br()
 htmltools::br()
 htmltools::br()
-
 ```
 
 
@@ -210,11 +212,11 @@ htmltools::br()
 
 
 ```{r active_tab_class4, echo = F, results = "asis"}
-if(missing_class_items[['class4']][['ClinVar']] == F | (missing_class_items[['class4']][['Other']] == T & missing_class_items[['class4']][['ClinVar']] == T)){
+if (missing_class_items[["class4"]][["ClinVar"]] == F | (missing_class_items[["class4"]][["Other"]] == T & missing_class_items[["class4"]][["ClinVar"]] == T)) {
   cat("")
   cat("#### ClinVar {.active}")
   cat("")
-}else{
+} else {
   cat("")
   cat("#### ClinVar")
   cat("")
@@ -223,22 +225,24 @@ if(missing_class_items[['class4']][['ClinVar']] == F | (missing_class_items[['cl
 
 ```{r class4_cpsr_clinvar, echo=F, results = 'asis', eval = show_class_filters[['class4']][['ClinVar']]}
 
-cat('\n')
+cat("\n")
 htmltools::br()
 
-variants_class4_clinvar <- 
-  dplyr::filter(cps_report[['content']][['snv_indel']][["disp"]][['class4']], CPSR_CLASSIFICATION_SOURCE == 'ClinVar')
+variants_class4_clinvar <-
+  dplyr::filter(cps_report[["content"]][["snv_indel"]][["disp"]][["class4"]], CPSR_CLASSIFICATION_SOURCE == "ClinVar")
 
-if(NROW(variants_class4_clinvar) > 2000){
-  cat('<b>NOTE - only considering top 2000 variants (due to limitations with client-side tables) </b><br>',sep="\n")
-  cat('<br>')
-  variants_class4_clinvar <- 
+if (NROW(variants_class4_clinvar) > 2000) {
+  cat("<b>NOTE - only considering top 2000 variants (due to limitations with client-side tables) </b><br>", sep = "\n")
+  cat("<br>")
+  variants_class4_clinvar <-
     head(variants_class4_clinvar, 2000)
 }
 
-variants_class4_clinvar <- variants_class4_clinvar %>% 
-  dplyr::select(-c(CPSR_CLASSIFICATION,CPSR_PATHOGENICITY_SCORE,
-                   CPSR_CLASSIFICATION_DOC,CPSR_CLASSIFICATION_CODE))
+variants_class4_clinvar <- variants_class4_clinvar %>%
+  dplyr::select(-c(
+    CPSR_CLASSIFICATION, CPSR_PATHOGENICITY_SCORE,
+    CPSR_CLASSIFICATION_DOC, CPSR_CLASSIFICATION_CODE
+  ))
 
 variants_class4_1 <- crosstalk::SharedData$new(variants_class4_clinvar)
 crosstalk::bscols(
@@ -251,41 +255,41 @@ crosstalk::bscols(
     crosstalk::filter_select("CLINVAR_PHENOTYPE", "ClinVar phenotype(s)", variants_class4_1, ~CLINVAR_PHENOTYPE),
     crosstalk::filter_slider("CLINVAR_REVIEW_STATUS_STARS", "ClinVar review status stars", variants_class4_1, ~CLINVAR_REVIEW_STATUS_STARS, min = 0, max = 4, step = 1, ticks = T),
     crosstalk::filter_select("CLINVAR_CONFLICTED", "ClinVar conflicting interpretations", variants_class4_1, ~CLINVAR_CONFLICTED),
-    crosstalk::filter_slider(tag_gnomad, paste0("MAF gnomAD (",desc_gnomad,")"), variants_class4_1, formula_gnomad, sep="",ticks = F)
+    crosstalk::filter_slider(tag_gnomad, paste0("MAF gnomAD (", desc_gnomad, ")"), variants_class4_1, formula_gnomad, sep = "", ticks = F)
   )
 )
 
-    
+
 
 htmltools::br()
 htmltools::br()
 
-DT::datatable(variants_class4_1, escape=F,extensions=c("Buttons","Responsive"),
-              options = list(
-                 pageLength = dtable_pageLength,
-                  #scrollY = dtable_scrollY,
-                  scrollCollapse = T,
-                buttons = c('csv','excel'),
-                dom = 'Bfrtip',
-                initComplete = DT::JS(
-                  "function(settings, json) {",
-                  "$(this.api().table().header()).css({'background-color':'#D53E4F', 'color': '#fff'});",
-                  "}")
-              )
+DT::datatable(variants_class4_1,
+  escape = F, extensions = c("Buttons", "Responsive"),
+  options = list(
+    pageLength = dtable_pageLength,
+    # scrollY = dtable_scrollY,
+    scrollCollapse = T,
+    buttons = c("csv", "excel"),
+    dom = "Bfrtip",
+    initComplete = DT::JS(
+      "function(settings, json) {",
+      "$(this.api().table().header()).css({'background-color':'#D53E4F', 'color': '#fff'});",
+      "}"
+    )
+  )
 )
 htmltools::br()
 htmltools::br()
 htmltools::br()
-
-
 ```
 
 ```{r active2_tab_class4, echo = F, results = "asis"}
-if(missing_class_items[['class4']][['ClinVar']] == T & missing_class_items[['class4']][['Other']] == F){
+if (missing_class_items[["class4"]][["ClinVar"]] == T & missing_class_items[["class4"]][["Other"]] == F) {
   cat("")
   cat("#### Non-ClinVar {.active}")
   cat("")
-}else{
+} else {
   cat("")
   cat("#### Non-ClinVar")
   cat("")
@@ -294,22 +298,24 @@ if(missing_class_items[['class4']][['ClinVar']] == T & missing_class_items[['cla
 
 ```{r class4_cpsr_other, echo=F, results = 'asis', eval = show_class_filters[['class4']][['Other']]}
 
-cat('\n')
+cat("\n")
 htmltools::br()
 
-variants_class4_other <- 
-  dplyr::filter(cps_report[['content']][['snv_indel']][["disp"]][['class4']], CPSR_CLASSIFICATION_SOURCE == 'Other')
+variants_class4_other <-
+  dplyr::filter(cps_report[["content"]][["snv_indel"]][["disp"]][["class4"]], CPSR_CLASSIFICATION_SOURCE == "Other")
 
-if(NROW(variants_class4_other) > 2000){
-  cat('<b>NOTE - only considering top 2000 variants (ranked according to CPSR classification score) </b><br>',sep="\n")
-  cat('<br>')
-  variants_class4_other <- 
+if (NROW(variants_class4_other) > 2000) {
+  cat("<b>NOTE - only considering top 2000 variants (ranked according to CPSR classification score) </b><br>", sep = "\n")
+  cat("<br>")
+  variants_class4_other <-
     head(variants_class4_other, 2000)
 }
 
-variants_class4_other <- variants_class4_other %>% 
-  dplyr::select(-c(CLINVAR, CLINVAR_REVIEW_STATUS_STARS, CLINVAR_VARIANT_ORIGIN, 
-                   CLINVAR_CLASSIFICATION, CLINVAR_CONFLICTED, CLINVAR_PHENOTYPE))
+variants_class4_other <- variants_class4_other %>%
+  dplyr::select(-c(
+    CLINVAR, CLINVAR_REVIEW_STATUS_STARS, CLINVAR_VARIANT_ORIGIN,
+    CLINVAR_CLASSIFICATION, CLINVAR_CONFLICTED, CLINVAR_PHENOTYPE
+  ))
 
 variants_class4_2 <- crosstalk::SharedData$new(variants_class4_other)
 crosstalk::bscols(
@@ -321,7 +327,7 @@ crosstalk::bscols(
   list(
     crosstalk::filter_select("CPSR_CLASSIFICATION_CODE", "CPSR classification (ACMG criteria codes)", variants_class4_2, ~CPSR_CLASSIFICATION_CODE),
     crosstalk::filter_slider("CPSR_PATHOGENICITY_SCORE", "CPSR pathogenicity score", variants_class4_2, ~CPSR_PATHOGENICITY_SCORE, step = 0.5, ticks = T),
-    crosstalk::filter_slider(tag_gnomad, paste0("MAF gnomAD (",desc_gnomad,")"), variants_class4_2, formula_gnomad, sep="",ticks = F)
+    crosstalk::filter_slider(tag_gnomad, paste0("MAF gnomAD (", desc_gnomad, ")"), variants_class4_2, formula_gnomad, sep = "", ticks = F)
   )
 )
 
@@ -330,24 +336,25 @@ crosstalk::bscols(
 htmltools::br()
 htmltools::br()
 
-DT::datatable(variants_class4_2, escape=F,extensions=c("Buttons","Responsive"),
-              options = list(
-                 pageLength = dtable_pageLength,
-                  #scrollY = dtable_scrollY,
-                  scrollCollapse = T,
-                buttons = c('csv','excel'),
-                dom = 'Bfrtip',
-                initComplete = DT::JS(
-                  "function(settings, json) {",
-                  "$(this.api().table().header()).css({'background-color':'#D53E4F', 'color': '#fff'});",
-                  "}")
-              )
+DT::datatable(variants_class4_2,
+  escape = F, extensions = c("Buttons", "Responsive"),
+  options = list(
+    pageLength = dtable_pageLength,
+    # scrollY = dtable_scrollY,
+    scrollCollapse = T,
+    buttons = c("csv", "excel"),
+    dom = "Bfrtip",
+    initComplete = DT::JS(
+      "function(settings, json) {",
+      "$(this.api().table().header()).css({'background-color':'#D53E4F', 'color': '#fff'});",
+      "}"
+    )
+  )
 )
 
 htmltools::br()
 htmltools::br()
 htmltools::br()
-
 ```
 
 
@@ -367,11 +374,11 @@ htmltools::br()
 
 
 ```{r active_tab_class3, echo = F, results = "asis"}
-if(missing_class_items[['class3']][['ClinVar']] == F | (missing_class_items[['class3']][['Other']] == T & missing_class_items[['class3']][['ClinVar']] == T)){
+if (missing_class_items[["class3"]][["ClinVar"]] == F | (missing_class_items[["class3"]][["Other"]] == T & missing_class_items[["class3"]][["ClinVar"]] == T)) {
   cat("")
   cat("#### ClinVar {.active}")
   cat("")
-}else{
+} else {
   cat("")
   cat("#### ClinVar")
   cat("")
@@ -380,22 +387,24 @@ if(missing_class_items[['class3']][['ClinVar']] == F | (missing_class_items[['cl
 
 ```{r class3_cpsr_clinvar, echo=F, results = 'asis', eval = show_class_filters[['class3']][['ClinVar']]}
 
-cat('\n')
+cat("\n")
 htmltools::br()
 
-variants_class3_clinvar <- 
-  dplyr::filter(cps_report[['content']][['snv_indel']][["disp"]][['class3']], CPSR_CLASSIFICATION_SOURCE == 'ClinVar')
+variants_class3_clinvar <-
+  dplyr::filter(cps_report[["content"]][["snv_indel"]][["disp"]][["class3"]], CPSR_CLASSIFICATION_SOURCE == "ClinVar")
 
-if(NROW(variants_class3_clinvar) > 2000){
-  cat('<b>NOTE - only considering top 2000 variants (due to limitations with client-side tables) </b><br>',sep="\n")
-  cat('<br>')
-  variants_class3_clinvar <- 
+if (NROW(variants_class3_clinvar) > 2000) {
+  cat("<b>NOTE - only considering top 2000 variants (due to limitations with client-side tables) </b><br>", sep = "\n")
+  cat("<br>")
+  variants_class3_clinvar <-
     head(variants_class3_clinvar, 2000)
 }
 
-variants_class3_clinvar <- variants_class3_clinvar %>% 
-  dplyr::select(-c(CPSR_CLASSIFICATION,CPSR_PATHOGENICITY_SCORE,
-                   CPSR_CLASSIFICATION_DOC,CPSR_CLASSIFICATION_CODE))
+variants_class3_clinvar <- variants_class3_clinvar %>%
+  dplyr::select(-c(
+    CPSR_CLASSIFICATION, CPSR_PATHOGENICITY_SCORE,
+    CPSR_CLASSIFICATION_DOC, CPSR_CLASSIFICATION_CODE
+  ))
 
 variants_class3_1 <- crosstalk::SharedData$new(variants_class3_clinvar)
 crosstalk::bscols(
@@ -403,9 +412,10 @@ crosstalk::bscols(
     crosstalk::filter_select("CONSEQUENCE", "Consequence", variants_class3_1, ~CONSEQUENCE),
     crosstalk::filter_checkbox("GENOTYPE", "Genotype", variants_class3_1, ~GENOTYPE),
     crosstalk::filter_select("SYMBOL", "Gene", variants_class3_1, ~SYMBOL),
-    crosstalk::filter_slider("GERP_SCORE","Genomic conservation score (GERP)",variants_class3_1, ~GERP_SCORE,
-                             min = -12.3, max = 6.17, ticks = T),
-    crosstalk::filter_slider(tag_gnomad, paste0("MAF gnomAD (",desc_gnomad,")"), variants_class3_1, formula_gnomad, sep="",ticks = F)
+    crosstalk::filter_slider("GERP_SCORE", "Genomic conservation score (GERP)", variants_class3_1, ~GERP_SCORE,
+      min = -12.3, max = 6.17, ticks = T
+    ),
+    crosstalk::filter_slider(tag_gnomad, paste0("MAF gnomAD (", desc_gnomad, ")"), variants_class3_1, formula_gnomad, sep = "", ticks = F)
   ),
   list(
     crosstalk::filter_select("miRNA_TARGET_HIT", "miRNA target gain/loss", variants_class3_1, ~miRNA_TARGET_HIT),
@@ -421,32 +431,33 @@ crosstalk::bscols(
 htmltools::br()
 htmltools::br()
 
-  DT::datatable(variants_class3_1, escape=F,extensions=c("Buttons","Responsive"),
-                options = list(
-                  pageLength = dtable_pageLength,
-                  #scrollY = dtable_scrollY,
-                  scrollCollapse = T,
-                  buttons = c('csv','excel'),
-                  dom = 'Bfrtip',
-                  initComplete = DT::JS(
-                  "function(settings, json) {",
-                  "$(this.api().table().header()).css({'background-color':'#000000', 'color': '#fff'});",
-                  "}")
-                )
+DT::datatable(variants_class3_1,
+  escape = F, extensions = c("Buttons", "Responsive"),
+  options = list(
+    pageLength = dtable_pageLength,
+    # scrollY = dtable_scrollY,
+    scrollCollapse = T,
+    buttons = c("csv", "excel"),
+    dom = "Bfrtip",
+    initComplete = DT::JS(
+      "function(settings, json) {",
+      "$(this.api().table().header()).css({'background-color':'#000000', 'color': '#fff'});",
+      "}"
+    )
   )
+)
 
 htmltools::br()
 htmltools::br()
 htmltools::br()
-
 ```
 
 ```{r active2_tab_class3, echo = F, results = "asis"}
-if(missing_class_items[['class3']][['ClinVar']] == T & missing_class_items[['class3']][['Other']] == F){
+if (missing_class_items[["class3"]][["ClinVar"]] == T & missing_class_items[["class3"]][["Other"]] == F) {
   cat("")
   cat("#### Non-ClinVar {.active}")
   cat("")
-}else{
+} else {
   cat("")
   cat("#### Non-ClinVar")
   cat("")
@@ -467,22 +478,24 @@ htmltools::br()
 
 ```{r class3_cpsr_other, echo=F, results = 'asis', eval = show_class_filters[['class3']][['Other']]}
 
-cat('\n')
+cat("\n")
 htmltools::br()
 
-variants_class3_other <- 
-  dplyr::filter(cps_report[['content']][['snv_indel']][["disp"]][['class3']], CPSR_CLASSIFICATION_SOURCE == 'Other')
+variants_class3_other <-
+  dplyr::filter(cps_report[["content"]][["snv_indel"]][["disp"]][["class3"]], CPSR_CLASSIFICATION_SOURCE == "Other")
 
-if(NROW(variants_class3_other) > 2000){
-  cat('<b>NOTE - only considering top 2000 variants (ranked according to CPSR classification score) </b><br>',sep="\n")
-  cat('<br>')
-  variants_class3_other <- 
+if (NROW(variants_class3_other) > 2000) {
+  cat("<b>NOTE - only considering top 2000 variants (ranked according to CPSR classification score) </b><br>", sep = "\n")
+  cat("<br>")
+  variants_class3_other <-
     head(variants_class3_other, 2000)
 }
 
-variants_class3_other <- variants_class3_other %>% 
-  dplyr::select(-c(CLINVAR, CLINVAR_REVIEW_STATUS_STARS, CLINVAR_VARIANT_ORIGIN, 
-                   CLINVAR_CLASSIFICATION, CLINVAR_CONFLICTED, CLINVAR_PHENOTYPE))
+variants_class3_other <- variants_class3_other %>%
+  dplyr::select(-c(
+    CLINVAR, CLINVAR_REVIEW_STATUS_STARS, CLINVAR_VARIANT_ORIGIN,
+    CLINVAR_CLASSIFICATION, CLINVAR_CONFLICTED, CLINVAR_PHENOTYPE
+  ))
 
 variants_class3_2 <- crosstalk::SharedData$new(variants_class3_other)
 crosstalk::bscols(
@@ -490,15 +503,16 @@ crosstalk::bscols(
     crosstalk::filter_select("CONSEQUENCE", "Consequence", variants_class3_2, ~CONSEQUENCE),
     crosstalk::filter_checkbox("GENOTYPE", "Genotype", variants_class3_2, ~GENOTYPE),
     crosstalk::filter_select("SYMBOL", "Gene", variants_class3_2, ~SYMBOL),
-    crosstalk::filter_slider("GERP_SCORE","Genomic conservation score (GERP)",variants_class3_2, ~GERP_SCORE,
-                             min = -12.3, max = 6.17, ticks = T)
+    crosstalk::filter_slider("GERP_SCORE", "Genomic conservation score (GERP)", variants_class3_2, ~GERP_SCORE,
+      min = -12.3, max = 6.17, ticks = T
+    )
   ),
   list(
     crosstalk::filter_select("miRNA_TARGET_HIT", "miRNA target gain/loss", variants_class3_2, ~miRNA_TARGET_HIT),
     crosstalk::filter_select("TF_BINDING_SITE_VARIANT", "TF binding site alteration", variants_class3_2, ~TF_BINDING_SITE_VARIANT),
     crosstalk::filter_select("CPSR_CLASSIFICATION_CODE", "CPSR classification (ACMG criteria codes)", variants_class3_2, ~CPSR_CLASSIFICATION_CODE),
     crosstalk::filter_slider("CPSR_PATHOGENICITY_SCORE", "CPSR pathogenicity score", variants_class3_2, ~CPSR_PATHOGENICITY_SCORE, step = 0.5, ticks = T),
-    crosstalk::filter_slider(tag_gnomad, paste0("MAF gnomAD (",desc_gnomad,")"), variants_class3_2, formula_gnomad, sep="",ticks = F)
+    crosstalk::filter_slider(tag_gnomad, paste0("MAF gnomAD (", desc_gnomad, ")"), variants_class3_2, formula_gnomad, sep = "", ticks = F)
   )
 )
 
@@ -507,32 +521,34 @@ crosstalk::bscols(
 htmltools::br()
 htmltools::br()
 
-DT::datatable(variants_class3_2, escape=F,extensions=c("Buttons","Responsive"),
-              options = list(
-                 pageLength = dtable_pageLength,
-                  #scrollY = dtable_scrollY,
-                  scrollCollapse = T,
-                buttons = c('csv','excel'),
-                dom = 'Bfrtip',
-                initComplete = DT::JS(
-                  "function(settings, json) {",
-                  "$(this.api().table().header()).css({'background-color':'#000000', 'color': '#fff'});",
-                  "}")
-              ) 
-) %>%
-  DT::formatStyle(color = "black", 
-                  columns = "SYMBOL", 
-                  valueColumns = "CPSR_PATHOGENICITY_SCORE", 
-                  backgroundColor = DT::styleEqual(
-                    c(-1.0, -0.5, 0, 0.5, 1.0, 1.5, 2.0),
-                    c('#FFFFFF','#FFFFFF','#FFFFFF','#FFFFFF','#FFFFFF','#FFFFFF','#ff7518')
-                  )
+DT::datatable(variants_class3_2,
+  escape = F, extensions = c("Buttons", "Responsive"),
+  options = list(
+    pageLength = dtable_pageLength,
+    # scrollY = dtable_scrollY,
+    scrollCollapse = T,
+    buttons = c("csv", "excel"),
+    dom = "Bfrtip",
+    initComplete = DT::JS(
+      "function(settings, json) {",
+      "$(this.api().table().header()).css({'background-color':'#000000', 'color': '#fff'});",
+      "}"
+    )
   )
- 
-htmltools::br()
-htmltools::br()
-htmltools::br()
+) %>%
+  DT::formatStyle(
+    color = "black",
+    columns = "SYMBOL",
+    valueColumns = "CPSR_PATHOGENICITY_SCORE",
+    backgroundColor = DT::styleEqual(
+      c(-1.0, -0.5, 0, 0.5, 1.0, 1.5, 2.0),
+      c("#FFFFFF", "#FFFFFF", "#FFFFFF", "#FFFFFF", "#FFFFFF", "#FFFFFF", "#ff7518")
+    )
+  )
 
+htmltools::br()
+htmltools::br()
+htmltools::br()
 ```
 
 <!--
@@ -549,11 +565,11 @@ htmltools::br()
 
 
 ```{r active_tab_class2, echo = F, results = "asis"}
-if(missing_class_items[['class2']][['ClinVar']] == F | (missing_class_items[['class2']][['Other']] == T & missing_class_items[['class2']][['ClinVar']] == T)){
+if (missing_class_items[["class2"]][["ClinVar"]] == F | (missing_class_items[["class2"]][["Other"]] == T & missing_class_items[["class2"]][["ClinVar"]] == T)) {
   cat("")
   cat("#### ClinVar {.active}")
   cat("")
-}else{
+} else {
   cat("")
   cat("#### ClinVar")
   cat("")
@@ -562,22 +578,24 @@ if(missing_class_items[['class2']][['ClinVar']] == F | (missing_class_items[['cl
 
 ```{r class2_cpsr_clinvar, echo=F, results = 'asis', eval = show_class_filters[['class2']][['ClinVar']]}
 
-cat('\n')
+cat("\n")
 htmltools::br()
 
-variants_class2_clinvar <- 
-  dplyr::filter(cps_report[['content']][['snv_indel']][["disp"]][['class2']], CPSR_CLASSIFICATION_SOURCE == 'ClinVar')
+variants_class2_clinvar <-
+  dplyr::filter(cps_report[["content"]][["snv_indel"]][["disp"]][["class2"]], CPSR_CLASSIFICATION_SOURCE == "ClinVar")
 
-if(NROW(variants_class2_clinvar) > 2000){
-  cat('<b>NOTE - only considering top 2000 variants (due to limitations with client-side tables) </b><br>',sep="\n")
-  cat('<br>')
-  variants_class2_clinvar <- 
+if (NROW(variants_class2_clinvar) > 2000) {
+  cat("<b>NOTE - only considering top 2000 variants (due to limitations with client-side tables) </b><br>", sep = "\n")
+  cat("<br>")
+  variants_class2_clinvar <-
     head(variants_class2_clinvar, 2000)
 }
 
-variants_class2_clinvar <- variants_class2_clinvar %>% 
-  dplyr::select(-c(CPSR_CLASSIFICATION,CPSR_PATHOGENICITY_SCORE,
-                   CPSR_CLASSIFICATION_DOC,CPSR_CLASSIFICATION_CODE))
+variants_class2_clinvar <- variants_class2_clinvar %>%
+  dplyr::select(-c(
+    CPSR_CLASSIFICATION, CPSR_PATHOGENICITY_SCORE,
+    CPSR_CLASSIFICATION_DOC, CPSR_CLASSIFICATION_CODE
+  ))
 
 variants_class2_1 <- crosstalk::SharedData$new(variants_class2_clinvar)
 crosstalk::bscols(
@@ -590,7 +608,7 @@ crosstalk::bscols(
     crosstalk::filter_select("CLINVAR_PHENOTYPE", "ClinVar phenotype(s)", variants_class2_1, ~CLINVAR_PHENOTYPE),
     crosstalk::filter_slider("CLINVAR_REVIEW_STATUS_STARS", "ClinVar review status stars", variants_class2_1, ~CLINVAR_REVIEW_STATUS_STARS, min = 0, max = 4, step = 1, ticks = T),
     crosstalk::filter_select("CLINVAR_CONFLICTED", "ClinVar conflicting interpretations", variants_class2_1, ~CLINVAR_CONFLICTED),
-    crosstalk::filter_slider(tag_gnomad, paste0("MAF gnomAD (",desc_gnomad,")"), variants_class2_1, formula_gnomad, sep="",ticks = F)
+    crosstalk::filter_slider(tag_gnomad, paste0("MAF gnomAD (", desc_gnomad, ")"), variants_class2_1, formula_gnomad, sep = "", ticks = F)
   )
 )
 
@@ -599,32 +617,33 @@ crosstalk::bscols(
 htmltools::br()
 htmltools::br()
 
-DT::datatable(variants_class2_1, escape=F,extensions=c("Buttons","Responsive"),
-              options = list(
-                 pageLength = dtable_pageLength,
-                  #scrollY = dtable_scrollY,
-                  scrollCollapse = T,
-                buttons = c('csv','excel'),
-                dom = 'Bfrtip',
-                initComplete = DT::JS(
-                  "function(settings, json) {",
-                  "$(this.api().table().header()).css({'background-color':'#78C679', 'color': '#fff'});",
-                  "}")
-              )
+DT::datatable(variants_class2_1,
+  escape = F, extensions = c("Buttons", "Responsive"),
+  options = list(
+    pageLength = dtable_pageLength,
+    # scrollY = dtable_scrollY,
+    scrollCollapse = T,
+    buttons = c("csv", "excel"),
+    dom = "Bfrtip",
+    initComplete = DT::JS(
+      "function(settings, json) {",
+      "$(this.api().table().header()).css({'background-color':'#78C679', 'color': '#fff'});",
+      "}"
+    )
+  )
 )
 
 htmltools::br()
 htmltools::br()
 htmltools::br()
-
 ```
 
 ```{r active2_tab_class2, echo = F, results = "asis"}
-if(missing_class_items[['class2']][['ClinVar']] == T & missing_class_items[['class2']][['Other']] == F){
+if (missing_class_items[["class2"]][["ClinVar"]] == T & missing_class_items[["class2"]][["Other"]] == F) {
   cat("")
   cat("#### Non-ClinVar {.active}")
   cat("")
-}else{
+} else {
   cat("")
   cat("#### Non-ClinVar")
   cat("")
@@ -633,22 +652,24 @@ if(missing_class_items[['class2']][['ClinVar']] == T & missing_class_items[['cla
 
 ```{r class2_cpsr_other, echo=F, results = 'asis', eval = show_class_filters[['class2']][['Other']]}
 
-cat('\n')
+cat("\n")
 htmltools::br()
 
-variants_class2_other <- 
-  dplyr::filter(cps_report[['content']][['snv_indel']][["disp"]][['class2']], CPSR_CLASSIFICATION_SOURCE == 'Other')
+variants_class2_other <-
+  dplyr::filter(cps_report[["content"]][["snv_indel"]][["disp"]][["class2"]], CPSR_CLASSIFICATION_SOURCE == "Other")
 
-if(NROW(variants_class2_other) > 2000){
-  cat('<b>NOTE - only considering top 2000 variants (ranked according to CPSR classification score) </b><br>',sep="\n")
-  cat('<br>')
-  variants_class2_other <- 
+if (NROW(variants_class2_other) > 2000) {
+  cat("<b>NOTE - only considering top 2000 variants (ranked according to CPSR classification score) </b><br>", sep = "\n")
+  cat("<br>")
+  variants_class2_other <-
     head(variants_class2_other, 2000)
 }
 
-variants_class2_other <- variants_class2_other %>% 
-  dplyr::select(-c(CLINVAR, CLINVAR_REVIEW_STATUS_STARS, CLINVAR_VARIANT_ORIGIN, 
-                   CLINVAR_CLASSIFICATION, CLINVAR_CONFLICTED, CLINVAR_PHENOTYPE))
+variants_class2_other <- variants_class2_other %>%
+  dplyr::select(-c(
+    CLINVAR, CLINVAR_REVIEW_STATUS_STARS, CLINVAR_VARIANT_ORIGIN,
+    CLINVAR_CLASSIFICATION, CLINVAR_CONFLICTED, CLINVAR_PHENOTYPE
+  ))
 
 variants_class2_2 <- crosstalk::SharedData$new(variants_class2_other)
 crosstalk::bscols(
@@ -660,7 +681,7 @@ crosstalk::bscols(
   list(
     crosstalk::filter_select("CPSR_CLASSIFICATION_CODE", "CPSR classification (ACMG criteria codes)", variants_class2_2, ~CPSR_CLASSIFICATION_CODE),
     crosstalk::filter_slider("CPSR_PATHOGENICITY_SCORE", "CPSR pathogenicity score", variants_class2_2, ~CPSR_PATHOGENICITY_SCORE, step = 0.5, ticks = T),
-    crosstalk::filter_slider(tag_gnomad, paste0("MAF gnomAD (",desc_gnomad,")"), variants_class2_2, formula_gnomad, sep="",ticks = F)
+    crosstalk::filter_slider(tag_gnomad, paste0("MAF gnomAD (", desc_gnomad, ")"), variants_class2_2, formula_gnomad, sep = "", ticks = F)
   )
 )
 
@@ -669,24 +690,24 @@ crosstalk::bscols(
 htmltools::br()
 htmltools::br()
 
-DT::datatable(variants_class2_2, escape=F,extensions=c("Buttons","Responsive"), 
-              options = list(
-                 pageLength = dtable_pageLength,
-                  #scrollY = dtable_scrollY,
-                  scrollCollapse = T,
-                buttons = c('csv','excel'),
-                dom = 'Bfrtip',
-                initComplete = DT::JS(
-                  "function(settings, json) {",
-                  "$(this.api().table().header()).css({'background-color':'#78C679', 'color': '#fff'});",
-                  "}")
-              )
+DT::datatable(variants_class2_2,
+  escape = F, extensions = c("Buttons", "Responsive"),
+  options = list(
+    pageLength = dtable_pageLength,
+    # scrollY = dtable_scrollY,
+    scrollCollapse = T,
+    buttons = c("csv", "excel"),
+    dom = "Bfrtip",
+    initComplete = DT::JS(
+      "function(settings, json) {",
+      "$(this.api().table().header()).css({'background-color':'#78C679', 'color': '#fff'});",
+      "}"
+    )
+  )
 )
 htmltools::br()
 htmltools::br()
 htmltools::br()
-
-
 ```
 
 <!--
@@ -705,11 +726,11 @@ htmltools::br()
 
 
 ```{r active_tab_class1, echo = F, results = "asis"}
-if(missing_class_items[['class1']][['ClinVar']] == F | (missing_class_items[['class1']][['Other']] == T & missing_class_items[['class1']][['ClinVar']] == T)){
+if (missing_class_items[["class1"]][["ClinVar"]] == F | (missing_class_items[["class1"]][["Other"]] == T & missing_class_items[["class1"]][["ClinVar"]] == T)) {
   cat("")
   cat("#### ClinVar {.active}")
   cat("")
-}else{
+} else {
   cat("")
   cat("#### ClinVar")
   cat("")
@@ -718,22 +739,24 @@ if(missing_class_items[['class1']][['ClinVar']] == F | (missing_class_items[['cl
 
 ```{r class1_cpsr_clinvar, echo=F, results = 'asis', eval = show_class_filters[['class1']][['ClinVar']]}
 
-cat('\n')
+cat("\n")
 htmltools::br()
 
-variants_class1_clinvar <- 
-  dplyr::filter(cps_report[['content']][['snv_indel']][["disp"]][['class1']], CPSR_CLASSIFICATION_SOURCE == 'ClinVar')
+variants_class1_clinvar <-
+  dplyr::filter(cps_report[["content"]][["snv_indel"]][["disp"]][["class1"]], CPSR_CLASSIFICATION_SOURCE == "ClinVar")
 
-if(NROW(variants_class1_clinvar) > 2000){
-  cat('<b>NOTE - only considering top 2000 variants (due to limitations with client-side tables) </b><br>',sep="\n")
-  cat('<br>')
-  variants_class1_clinvar <- 
+if (NROW(variants_class1_clinvar) > 2000) {
+  cat("<b>NOTE - only considering top 2000 variants (due to limitations with client-side tables) </b><br>", sep = "\n")
+  cat("<br>")
+  variants_class1_clinvar <-
     head(variants_class1_clinvar, 2000)
 }
 
-variants_class1_clinvar <- variants_class1_clinvar %>% 
-  dplyr::select(-c(CPSR_CLASSIFICATION,CPSR_PATHOGENICITY_SCORE,
-                   CPSR_CLASSIFICATION_DOC,CPSR_CLASSIFICATION_CODE))
+variants_class1_clinvar <- variants_class1_clinvar %>%
+  dplyr::select(-c(
+    CPSR_CLASSIFICATION, CPSR_PATHOGENICITY_SCORE,
+    CPSR_CLASSIFICATION_DOC, CPSR_CLASSIFICATION_CODE
+  ))
 
 variants_class1_1 <- crosstalk::SharedData$new(variants_class1_clinvar)
 crosstalk::bscols(
@@ -746,7 +769,7 @@ crosstalk::bscols(
     crosstalk::filter_select("CLINVAR_PHENOTYPE", "ClinVar phenotype(s)", variants_class1_1, ~CLINVAR_PHENOTYPE),
     crosstalk::filter_slider("CLINVAR_REVIEW_STATUS_STARS", "ClinVar review status stars", variants_class1_1, ~CLINVAR_REVIEW_STATUS_STARS, min = 0, max = 4, step = 1, ticks = T),
     crosstalk::filter_select("CLINVAR_CONFLICTED", "ClinVar conflicting interpretations", variants_class1_1, ~CLINVAR_CONFLICTED),
-    crosstalk::filter_slider(tag_gnomad, paste0("MAF gnomAD (",desc_gnomad,")"), variants_class1_1, formula_gnomad, sep="",ticks = F)
+    crosstalk::filter_slider(tag_gnomad, paste0("MAF gnomAD (", desc_gnomad, ")"), variants_class1_1, formula_gnomad, sep = "", ticks = F)
   )
 )
 
@@ -755,34 +778,34 @@ crosstalk::bscols(
 htmltools::br()
 htmltools::br()
 
-DT::datatable(variants_class1_1, 
-              escape = F, 
-              extensions=c("Buttons","Responsive"), 
-              options = list(
-                 pageLength = dtable_pageLength,
-                  #scrollY = dtable_scrollY,
-                  scrollCollapse = T,
-                buttons = c('csv','excel'),
-                dom = 'Bfrtip',
-                initComplete = DT::JS(
-                  "function(settings, json) {",
-                  "$(this.api().table().header()).css({'background-color':'#077009', 'color': '#fff'});",
-                  "}")
-              )
+DT::datatable(variants_class1_1,
+  escape = F,
+  extensions = c("Buttons", "Responsive"),
+  options = list(
+    pageLength = dtable_pageLength,
+    # scrollY = dtable_scrollY,
+    scrollCollapse = T,
+    buttons = c("csv", "excel"),
+    dom = "Bfrtip",
+    initComplete = DT::JS(
+      "function(settings, json) {",
+      "$(this.api().table().header()).css({'background-color':'#077009', 'color': '#fff'});",
+      "}"
+    )
+  )
 )
 
 htmltools::br()
 htmltools::br()
 htmltools::br()
-
 ```
 
 ```{r active2_tab_class1, echo = F, results = "asis"}
-if(missing_class_items[['class1']][['ClinVar']] == T & missing_class_items[['class1']][['Other']] == F){
+if (missing_class_items[["class1"]][["ClinVar"]] == T & missing_class_items[["class1"]][["Other"]] == F) {
   cat("")
   cat("#### Non-ClinVar {.active}")
   cat("")
-}else{
+} else {
   cat("")
   cat("#### Non-ClinVar")
   cat("")
@@ -791,22 +814,24 @@ if(missing_class_items[['class1']][['ClinVar']] == T & missing_class_items[['cla
 
 ```{r class1_cpsr_other, echo=F, results = 'asis', eval = show_class_filters[['class1']][['Other']]}
 
-cat('\n')
+cat("\n")
 htmltools::br()
 
-variants_class1_other <- 
-  dplyr::filter(cps_report[['content']][['snv_indel']][["disp"]][['class1']], CPSR_CLASSIFICATION_SOURCE == 'Other')
+variants_class1_other <-
+  dplyr::filter(cps_report[["content"]][["snv_indel"]][["disp"]][["class1"]], CPSR_CLASSIFICATION_SOURCE == "Other")
 
-if(NROW(variants_class1_other) > 2000){
-  cat('<b>NOTE - only considering top 2000 variants (ranked according to CPSR classification score) </b><br>',sep="\n")
-  cat('<br>')
-  variants_class1_other <- 
+if (NROW(variants_class1_other) > 2000) {
+  cat("<b>NOTE - only considering top 2000 variants (ranked according to CPSR classification score) </b><br>", sep = "\n")
+  cat("<br>")
+  variants_class1_other <-
     head(variants_class1_other, 2000)
 }
 
-variants_class1_other <- variants_class1_other %>% 
-  dplyr::select(-c(CLINVAR, CLINVAR_REVIEW_STATUS_STARS, CLINVAR_VARIANT_ORIGIN, 
-                   CLINVAR_CLASSIFICATION, CLINVAR_CONFLICTED, CLINVAR_PHENOTYPE))
+variants_class1_other <- variants_class1_other %>%
+  dplyr::select(-c(
+    CLINVAR, CLINVAR_REVIEW_STATUS_STARS, CLINVAR_VARIANT_ORIGIN,
+    CLINVAR_CLASSIFICATION, CLINVAR_CONFLICTED, CLINVAR_PHENOTYPE
+  ))
 
 variants_class1_2 <- crosstalk::SharedData$new(variants_class1_other)
 crosstalk::bscols(
@@ -818,7 +843,7 @@ crosstalk::bscols(
   list(
     crosstalk::filter_select("CPSR_CLASSIFICATION_CODE", "CPSR classification (ACMG criteria codes)", variants_class1_2, ~CPSR_CLASSIFICATION_CODE),
     crosstalk::filter_slider("CPSR_PATHOGENICITY_SCORE", "CPSR pathogenicity score", variants_class1_2, ~CPSR_PATHOGENICITY_SCORE, step = 0.5, ticks = T),
-    crosstalk::filter_slider(tag_gnomad, paste0("MAF gnomAD (",desc_gnomad,")"), variants_class1_2, formula_gnomad, sep="",ticks = F)
+    crosstalk::filter_slider(tag_gnomad, paste0("MAF gnomAD (", desc_gnomad, ")"), variants_class1_2, formula_gnomad, sep = "", ticks = F)
   )
 )
 
@@ -827,26 +852,26 @@ crosstalk::bscols(
 htmltools::br()
 htmltools::br()
 
-DT::datatable(variants_class1_2, escape=F,extensions=c("Buttons","Responsive"), 
-              options = list(
-                 pageLength = dtable_pageLength,
-                  #scrollY = dtable_scrollY,
-                  scrollCollapse = T,
-                buttons = c('csv','excel'),
-                dom = 'Bfrtip',
-                initComplete = 
-                  DT::JS(
-                  "function(settings, json) {",
-                  "$(this.api().table().header()).css({'background-color':'#077009', 'color': '#fff'});",
-                   "}")
-              )
+DT::datatable(variants_class1_2,
+  escape = F, extensions = c("Buttons", "Responsive"),
+  options = list(
+    pageLength = dtable_pageLength,
+    # scrollY = dtable_scrollY,
+    scrollCollapse = T,
+    buttons = c("csv", "excel"),
+    dom = "Bfrtip",
+    initComplete =
+      DT::JS(
+        "function(settings, json) {",
+        "$(this.api().table().header()).css({'background-color':'#077009', 'color': '#fff'});",
+        "}"
+      )
+  )
 )
 
 htmltools::br()
 htmltools::br()
 htmltools::br()
-
-
 ```
 
 

--- a/inst/templates/cpsr_rmarkdown/cpsr_virtual_panel.Rmd
+++ b/inst/templates/cpsr_rmarkdown/cpsr_virtual_panel.Rmd
@@ -9,7 +9,7 @@ Cancer predisposition geneset subject to analysis/screening in this report:
    *  `r cps_report[['metadata']][['gene_panel']][['confidence']]`
    
 ```{r gene_selection, echo = F, eval = T}
-tiles_html <- pcgrr::virtual_panel_display_html(gene_df = cps_report[['metadata']][['gene_panel']][['genes']])
+tiles_html <- pcgrr::virtual_panel_display_html(gene_df = cps_report[["metadata"]][["gene_panel"]][["genes"]])
 ```
 
 `r tiles_html`

--- a/inst/templates/cpsr_rmarkdown_report.Rmd
+++ b/inst/templates/cpsr_rmarkdown_report.Rmd
@@ -8,8 +8,8 @@ output: html_document
 ---
 
 ```{r global_options, include=FALSE}
-knitr::opts_chunk$set(echo = F,warning=FALSE, dpi=72, error=F, eval=T)
-options(scipen=999)
+knitr::opts_chunk$set(echo = F, warning = FALSE, dpi = 72, error = F, eval = T)
+options(scipen = 999)
 
 # width_panel <- 14
 # height_panel <- 3 + as.integer((max(0,(NROW(cps_report[['metadata']][['gene_panel']][['genes']]) - 24)) / 16))
@@ -22,18 +22,17 @@ set_all <- NROW(cps_report$content$snv_indel$variant_set$tsv)
 
 set_clinvar <- 0
 set_other <- 0
-if(cps_report$content$snv_indel$eval == T){
-  if(cps_report$content$snv_indel$v_stat$n > 0){
+if (cps_report$content$snv_indel$eval == T) {
+  if (cps_report$content$snv_indel$v_stat$n > 0) {
     set_clinvar <- NROW(cps_report$content$snv_indel$variant_set$tsv %>% dplyr::filter(!is.na(CLINVAR_CLASSIFICATION)))
     set_other <- NROW(cps_report$content$snv_indel$variant_set$tsv %>% dplyr::filter(is.na(CLINVAR_CLASSIFICATION) & !is.na(CPSR_CLASSIFICATION) > 0))
   }
 }
 
-if(set_other == 0 | set_clinvar == 0){
+if (set_other == 0 | set_clinvar == 0) {
   width_donut <- 6
   height_donut <- 4
 }
-
 ```
 
 ```{r settings_cpsr, child='cpsr_rmarkdown/cpsr_settings.Rmd'}
@@ -47,9 +46,9 @@ if(set_other == 0 | set_clinvar == 0){
 ```
 
 ```{r no_variants, eval = !cps_report[['content']][['snv_indel']][['eval']], results = "asis"}
-cat('<br><ul>')
+cat("<br><ul>")
 cat("<li><b>NO</b> variants found in the selected virtual gene panel/custom geneset</li>")
-cat('</ul><br>')
+cat("</ul><br>")
 ```
 
 
@@ -67,7 +66,7 @@ cat('</ul><br>')
 ```
 
 ```{r global_options2, include=FALSE}
-options(scipen=0)
+options(scipen = 0)
 ```
 
 ```{r conditional_gwas, child='cpsr_rmarkdown/cpsr_gwas.Rmd', eval = cps_report[['metadata']][['config']][['gwas']][['run']]}
@@ -80,4 +79,3 @@ options(scipen=0)
 
 
 ## References
-


### PR DESCRIPTION
Simply running `styler::tidyverse_style` to enforce a consistent style throughout the R/Rmd files. Takes care of things like single-to-double quotes, space, indentation etc.
Nothing was really wrong with the formatting of the files before; this just helps make things more consistent throughout and conforming to a standard.
Also added a [pre-commit](https://pre-commit.com/) config that runs the styler automatically locally before committing. Just need to do `pre-commit install` within the repo root to start using it.