### PR TITLE
Conda dependencies

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,4 @@
 ^pkgdown$
 ^_pkgdown\.yml$
 ^\.pre-commit-config\.yaml$
+^vignettes$

--- a/.github/workflows/build_conda.yaml
+++ b/.github/workflows/build_conda.yaml
@@ -54,7 +54,7 @@ jobs:
             micromamba activate pkgdown
             printf "cpsr version:\n"
             Rscript -e "packageVersion('cpsr')"
-            Rscript -e "pkgdown::deploy_to_branch(pkg = '.', commit_message = paste(pkgdown:::construct_commit_message('.'), '- see https://sigven.github.io/cpsr/'), branch = 'gh-pages', new_process = FALSE)"
+            Rscript -e "pkgdown::deploy_to_branch(pkg = '.', commit_message = 'Built site for CPSR - see https://sigven.github.io/cpsr/'), branch = 'gh-pages', new_process = FALSE)"
 
       - name: Create tag
         uses: actions/github-script@v7

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,11 +33,14 @@ Imports:
     assertthat,
     dplyr,
     ggplot2,
-    pcgrr,
-    rlang,
-    quarto,
+    glue,
     openxlsx2,
+    pcgrr,
+    quarto,
+    readr,
+    rlang,
     stringr,
+    stringi,
     tidyr
 Depends:
     R (>= 4.0)

--- a/conda/recipe/cpsr/build.sh
+++ b/conda/recipe/cpsr/build.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
 export DISABLE_AUTOBREW=1
-${R} -e "install.packages('devtools', repos = 'https://cloud.r-project.org/', lib = '${PREFIX}/lib/R/library')"
-${R} -e "devtools::install_github(repo = 'JanMarvin/openxlsx2', ref = 'v1.6', lib = '${PREFIX}/lib/R/library')"
+${R} -e "install.packages('openxlsx2', repos = 'https://cloud.r-project.org/', lib = '${PREFIX}/lib/R/library')"
 ${R} CMD INSTALL --build . ${R_ARGS}

--- a/conda/recipe/cpsr/build.sh
+++ b/conda/recipe/cpsr/build.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
 export DISABLE_AUTOBREW=1
+${R} -e "install.packages('devtools', repos = 'https://cloud.r-project.org/', lib = '${PREFIX}/lib/R/library')"
+${R} -e "devtools::install_github(repo = 'JanMarvin/openxlsx2', ref = 'v1.6', lib = '${PREFIX}/lib/R/library')"
 ${R} CMD INSTALL --build . ${R_ARGS}

--- a/conda/recipe/cpsr/meta.yaml
+++ b/conda/recipe/cpsr/meta.yaml
@@ -17,23 +17,31 @@ requirements:
     - git
   host:
     - r-base
-    - r-assertable
     - r-assertthat
     - r-dplyr
     - r-ggplot2
+    - r-glue
     - r-pcgrr
+    - r-quarto
+    - quarto
+    - r-readr
     - r-rlang
     - r-stringr
+    - r-stringi
     - r-tidyr
   run:
     - r-base
-    - r-assertable
     - r-assertthat
     - r-dplyr
     - r-ggplot2
+    - r-glue
     - r-pcgrr
+    - r-quarto
+    - quarto
+    - r-readr
     - r-rlang
     - r-stringr
+    - r-stringi
     - r-tidyr
 
 test:


### PR DESCRIPTION
Adding some dependencies and will see if openxlsx2 can be installed during the conda build process since it doesn't have a conda pkg.
Also, `vignettes` needed to be `.Rbuildignore`d.