### PR TITLE
Bump r-base to 4.3.3

### DIFF
--- a/.github/workflows/build_conda.yaml
+++ b/.github/workflows/build_conda.yaml
@@ -19,9 +19,6 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
-    strategy:
-      matrix:
-        r_version: ["4.2"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -29,9 +26,9 @@ jobs:
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: ${{ env.env_yml_path }}/condabuild_env.yml
-      - name: Build + upload cpsr conda pkg
+      - name: 🐍 Conda pkg build and upload
         run: |
-          conda mambabuild ${recipe_path}/cpsr --R=${{ matrix.r_version }} -c pcgr -c conda-forge -c bioconda --token ${atoken}
+          conda mambabuild ${recipe_path}/cpsr -c pcgr -c conda-forge -c bioconda --token ${atoken}
 
   pkgdown_site:
     name: Deploy pkgdown website

--- a/conda/recipe/cpsr/meta.yaml
+++ b/conda/recipe/cpsr/meta.yaml
@@ -16,7 +16,7 @@ requirements:
   build:
     - git
   host:
-    - r-base
+    - r-base ==4.3.3
     - r-assertthat
     - r-dplyr
     - r-ggplot2


### PR DESCRIPTION
We'll need to build this cpsr conda pkg first in order for the pcgrr conda _environment_ to pull it in.
Connected to https://github.com/sigven/pcgr/pull/227